### PR TITLE
chore: register timeline-viewer in .claude/launch.json

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "timeline-viewer",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "timeline", "run", "dev"],
+      "port": 5173
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/launch.json` registering the Vite dev server (`timeline/`) on port 5173 so it can be started via Claude Code's `preview_start` tool without falling back to a shell.
- Runs via `npm --prefix timeline run dev`, which keeps the root free of a `dev` script while still delegating to the viewer workspace.

## Why
Claude's preview harness reads `.claude/launch.json` to start dev servers. Without this file the viewer has to be launched with Bash, which bypasses the managed preview surface (port tracking, log capture, restart semantics).

## Out of scope / not in this PR
Session artifacts from `/autoingest` (today's day node, `.raw/git/` summary, wiki entity page, autoingest config tweak) are all gitignored by the vault's privacy model — they live locally only and are not part of this PR by design.

## Test plan
- [ ] `preview_start timeline-viewer` launches Vite on :5173
- [ ] Reopen in a fresh worktree to confirm config is picked up