### PR TITLE
feat: QMD integration spec + iCloud vault autoingest

### DIFF
--- a/.claude/skills/autoingest/SKILL.md
+++ b/.claude/skills/autoingest/SKILL.md
@@ -32,7 +32,7 @@ If the config file doesn't exist, create it with the default (see below).
 3. **For each new item**, dispatch to the appropriate handler:
 
    ### folder handler
-   - Walk all files in the configured path
+   - Walk all files in the configured path (recursively if `recursive: true`). Filter by `match` glob and `exclude` folder list if set.
    - For each unprocessed file: copy to `.raw/`, then run wiki-ingest single-source flow
    - Handle any file type: .md files are ingested as sources, images via vision flow, URLs extracted from .md files are fetched as child pages
    

--- a/.claude/skills/autoingest/references/folder.md
+++ b/.claude/skills/autoingest/references/folder.md
@@ -7,8 +7,32 @@ Watches a local directory for new files. Default: `inbox/unsorted/`.
 { "type": "folder", "path": "inbox/unsorted/", "kind": "any", "enabled": true }
 ```
 
+### Optional fields
+
+- **`recursive`** (bool, default `false`) — walk subdirectories recursively instead of listing only top-level files.
+- **`match`** (glob string, optional) — only process files matching this pattern (e.g. `"*.md"`).
+- **`exclude`** (string[], optional) — top-level subfolder names to skip entirely during walking. Checked against the first path component relative to `path`.
+
+Example with all optional fields:
+```json
+{
+  "type": "folder",
+  "path": "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/callum/",
+  "kind": "any",
+  "recursive": true,
+  "match": "*.md",
+  "exclude": ["Notion", ".obsidian", ".trash"],
+  "enabled": true
+}
+```
+
 ## Behavior
-1. List all files in `path`
+1. List files in `path`:
+   - If `recursive` is false (default): flat listing of `path`
+   - If `recursive` is true: `find "$path" -type f` with:
+     - `-not -path "*/<name>/*"` for each entry in `exclude`
+     - `-name "$match"` if `match` is set
+   - Always quote `"$path"` in shell commands (handles spaces in iCloud paths etc.)
 2. Check each against `.raw/.manifest.json`
 3. For unprocessed files:
    - Copy to `.raw/` (articles/ for .md, images/ for images)

--- a/.claude/skills/autoingest/references/folder.md
+++ b/.claude/skills/autoingest/references/folder.md
@@ -11,7 +11,7 @@ Watches a local directory for new files. Default: `inbox/unsorted/`.
 
 - **`recursive`** (bool, default `false`) — walk subdirectories recursively instead of listing only top-level files.
 - **`match`** (glob string, optional) — only process files matching this pattern (e.g. `"*.md"`).
-- **`exclude`** (string[], optional) — top-level subfolder names to skip entirely during walking. Checked against the first path component relative to `path`.
+- **`exclude`** (string[], optional) — top-level subfolder names to skip entirely during walking. Only matches the first path component relative to `path` (e.g. `"Notion"` skips `Notion/` but not `Technical/Notion/`).
 
 Example with all optional fields:
 ```json
@@ -30,7 +30,7 @@ Example with all optional fields:
 1. List files in `path`:
    - If `recursive` is false (default): flat listing of `path`
    - If `recursive` is true: `find "$path" -type f` with:
-     - `-not -path "*/<name>/*"` for each entry in `exclude`
+     - `-not -path "$path/<name>/*"` for each entry in `exclude` (anchored to base path, matches top-level only)
      - `-name "$match"` if `match` is set
    - Always quote `"$path"` in shell commands (handles spaces in iCloud paths etc.)
 2. Check each against `.raw/.manifest.json`

--- a/.claude/specs/qmd-integration/design.md
+++ b/.claude/specs/qmd-integration/design.md
@@ -1,0 +1,225 @@
+# QMD Integration — Design
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Claude Code Session                   │
+│                                                         │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  │
+│  │ /wiki-query  │  │ /superhuman  │  │  Direct MCP  │  │
+│  │   (skill)    │  │   (skill)    │  │  tool calls  │  │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘  │
+│         │                 │                  │          │
+│         └────────┬────────┴──────────────────┘          │
+│                  │                                      │
+│         ┌────────▼────────┐                             │
+│         │   QMD MCP Server │ ← settings.json            │
+│         │  query/get/...  │                             │
+│         └────────┬────────┘                             │
+│                  │ fallback if unavailable               │
+│         ┌────────▼────────┐                             │
+│         │   Grep + Read   │ ← existing approach          │
+│         └─────────────────┘                             │
+└─────────────────────────────────────────────────────────┘
+                   │
+          ┌────────▼────────┐
+          │ .qmd/index.sqlite│ ← vault-local DB
+          │  FTS5 + vectors  │
+          └────────┬────────┘
+                   │
+    ┌──────────────┼──────────────┐──────────────┐
+    │              │              │              │
+ wiki/        journal/       inbox/      .raw/articles/
+```
+
+## Decision Record
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| 1 | Collections | wiki + journal + inbox + .raw/articles | Covers all searchable content. Reminders too small, _attachments binary. |
+| 2 | Integration | MCP server + skill rewrites | MCP gives native tools; skill rewrites make /superhuman and /wiki-query semantically aware. |
+| 3 | Reindex trigger | Hook for `update`, batch `embed` at ingest end | FTS5 stays current on every write. Vector embeds batch at natural breakpoints (end of ingest runs). |
+| 4 | Viewer search | QMD HTTP server | Full hybrid search in browser. Requires QMD server running alongside dev server. |
+| 5 | Fallback | Graceful degradation to grep | QMD is progressive enhancement. Skills always work. |
+| 6 | Context metadata | Per-collection descriptions | Cheap to add, improves search quality. |
+| 7 | DB location | Vault-local .qmd/index.sqlite | Scoped to this vault. No collision with other QMD uses. |
+| 8 | Embedding model | Default (EmbeddingGemma-300M) | Vault is English-only. Qwen3-Embedding only needed for multilingual. |
+
+## Component Design
+
+### 1. QMD Setup Script
+
+New script: `scripts/setup-qmd.sh`
+
+```bash
+#!/bin/bash
+set -e
+
+DB=".qmd/index.sqlite"
+
+# Install if missing
+command -v qmd >/dev/null || npm install -g @tobilu/qmd
+
+# Create collections with vault-local DB
+qmd --db "$DB" collection add wiki/ --name wiki
+qmd --db "$DB" collection add journal/ --name journal
+qmd --db "$DB" collection add inbox/ --name inbox
+qmd --db "$DB" collection add .raw/articles/ --name raw-sources
+
+# Add context descriptions
+qmd --db "$DB" context add qmd://wiki "Curated knowledge base: concepts, entities, sources, and domain pages. Cross-referenced with wikilinks."
+qmd --db "$DB" context add qmd://journal "Daily timeline entries with activity counts, summaries, and sections for captures, ingests, code, and reminders."
+qmd --db "$DB" context add qmd://inbox "Quick notes and unprocessed captures. Fragments waiting to be promoted to wiki pages."
+qmd --db "$DB" context add qmd://raw-sources "Immutable source archive. Ingested articles, git summaries, and iCloud vault copies."
+
+# Initial index + embed
+qmd --db "$DB" update
+qmd --db "$DB" embed
+
+echo "QMD setup complete. Index at $DB"
+```
+
+### 2. MCP Server Config
+
+Add to `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "qmd": {
+      "command": "qmd",
+      "args": ["mcp", "--db", ".qmd/index.sqlite"]
+    }
+  }
+}
+```
+
+### 3. Skill Rewrites
+
+#### /wiki-query changes
+
+Replace grep-based search in Standard and Deep modes with QMD:
+
+```
+## Standard Query Workflow (updated)
+
+1. Read wiki/hot.md first (unchanged)
+2. Read wiki/index.md to orient (unchanged)
+3. **NEW**: Run `qmd query --db .qmd/index.sqlite --json -n 10 "<query>"`
+   - If QMD available: parse results, read top 3-5 matched pages
+   - If QMD unavailable: fall back to grep across wiki/ (existing behavior)
+4. Synthesize answer with citations (unchanged)
+5. Offer to file (unchanged)
+```
+
+Availability check:
+```bash
+qmd --db .qmd/index.sqlite status 2>/dev/null && echo "qmd_available" || echo "qmd_unavailable"
+```
+
+#### /superhuman changes
+
+Replace grep across all directories with QMD:
+
+```
+## Search Strategy (updated)
+
+1. Read wiki/hot.md for recent context (unchanged)
+2. **NEW**: Run `qmd query --db .qmd/index.sqlite --json -n 15 "<query>"`
+   - If QMD available: results span wiki + journal + inbox + .raw (all collections)
+   - If QMD unavailable: fall back to grep across all directories (existing behavior)
+3. Read top results (up to 10) (unchanged)
+4. LLM-rank by relevance (unchanged — QMD pre-ranks, LLM re-ranks with full context)
+5. Synthesize answer with citations (unchanged)
+```
+
+### 4. Reindex Hooks
+
+Add to `.claude/hooks/hooks.json`:
+
+**PostToolUse hook (Write/Edit):**
+```json
+{
+  "event": "PostToolUse",
+  "tools": ["Write", "Edit"],
+  "command": "qmd --db .qmd/index.sqlite update 2>/dev/null || true",
+  "timeout_ms": 5000
+}
+```
+
+**Autoingest / wiki-ingest epilogue:**
+
+Add to end of autoingest SKILL.md execution flow (step 7, after timeline rebuild):
+```
+8. **Reindex QMD**: run `qmd --db .qmd/index.sqlite update && qmd --db .qmd/index.sqlite embed` (if QMD installed).
+```
+
+Same for wiki-ingest SKILL.md (after step 10, update log):
+```
+12. **Reindex QMD**: run `qmd --db .qmd/index.sqlite update && qmd --db .qmd/index.sqlite embed` (if QMD installed).
+```
+
+### 5. Timeline Viewer Search
+
+#### Server changes
+
+Update `scripts/serve-timeline.sh` (or create it) to start QMD HTTP server alongside Vite:
+
+```bash
+# Start QMD HTTP server on port 3001
+qmd mcp --http --port 3001 --db .qmd/index.sqlite &
+QMD_PID=$!
+
+# Start Vite dev server on port 5175
+npx vite --port 5175 timeline/
+
+# Cleanup
+kill $QMD_PID
+```
+
+#### Frontend changes
+
+New component: `timeline/src/components/Search.tsx`
+
+```typescript
+// Calls QMD HTTP server at localhost:3001
+async function search(query: string): Promise<SearchResult[]> {
+  const res = await fetch('http://localhost:3001/query', {
+    method: 'POST',
+    body: JSON.stringify({ query, limit: 10 })
+  })
+  return res.json()
+}
+```
+
+Search results render as cards with:
+- Document title and path
+- Matched snippet (highlighted)
+- Score badge
+- Click → navigates to the matching day node or opens in Obsidian
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `scripts/setup-qmd.sh` | NEW — setup script |
+| `.claude/settings.json` | Add QMD MCP server |
+| `.claude/hooks/hooks.json` | Add PostToolUse qmd update hook |
+| `.claude/skills/wiki-query/SKILL.md` | Add QMD query step with grep fallback |
+| `.claude/skills/superhuman/SKILL.md` | Add QMD query step with grep fallback |
+| `.claude/skills/autoingest/SKILL.md` | Add qmd update+embed at end of flow |
+| `.claude/skills/wiki-ingest/SKILL.md` | Add qmd update+embed at end of flow |
+| `.gitignore` | Add `.qmd/` |
+| `timeline/src/components/Search.tsx` | NEW — search box component |
+| `timeline/src/components/Timeline.tsx` | Integrate Search component |
+| `scripts/serve-timeline.sh` | NEW or update — start QMD HTTP alongside Vite |
+
+## NOT in Scope
+
+| Item | Rationale | When |
+|------|-----------|------|
+| Custom embedding model (Qwen3) | Vault is English-only; default EmbeddingGemma is fine | If multilingual content added |
+| Per-subfolder context metadata | Per-collection is sufficient for current vault size | If search quality degrades |
+| QMD SDK integration (programmatic) | CLI + MCP is simpler; SDK adds a build dependency | If viewer search needs more control |
+| Scheduled reindex cron | Hook-based reindex is sufficient while sessions are active | If using daemon-mode autoingest |

--- a/.claude/specs/qmd-integration/design.md
+++ b/.claude/specs/qmd-integration/design.md
@@ -2,7 +2,7 @@
 
 ## Architecture Overview
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │                    Claude Code Session                   │
 │                                                         │
@@ -101,7 +101,7 @@ Add to `.claude/settings.json`:
 
 Replace grep-based search in Standard and Deep modes with QMD:
 
-```
+```text
 ## Standard Query Workflow (updated)
 
 1. Read wiki/hot.md first (unchanged)
@@ -122,7 +122,7 @@ qmd --db .qmd/index.sqlite status 2>/dev/null && echo "qmd_available" || echo "q
 
 Replace grep across all directories with QMD:
 
-```
+```text
 ## Search Strategy (updated)
 
 1. Read wiki/hot.md for recent context (unchanged)
@@ -136,27 +136,37 @@ Replace grep across all directories with QMD:
 
 ### 4. Reindex Hooks
 
-Add to `.claude/hooks/hooks.json`:
+Add a `PostToolUse` entry to `.claude/settings.json` under `hooks`:
 
 **PostToolUse hook (Write/Edit):**
 ```json
 {
-  "event": "PostToolUse",
-  "tools": ["Write", "Edit"],
-  "command": "qmd --db .qmd/index.sqlite update 2>/dev/null || true",
-  "timeout_ms": 5000
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "tool == \"Write\" || tool == \"Edit\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "qmd --db .qmd/index.sqlite update 2>/dev/null || true"
+          }
+        ],
+        "description": "Update QMD FTS5 index after file changes"
+      }
+    ]
+  }
 }
 ```
 
 **Autoingest / wiki-ingest epilogue:**
 
 Add to end of autoingest SKILL.md execution flow (step 7, after timeline rebuild):
-```
+```text
 8. **Reindex QMD**: run `qmd --db .qmd/index.sqlite update && qmd --db .qmd/index.sqlite embed` (if QMD installed).
 ```
 
 Same for wiki-ingest SKILL.md (after step 10, update log):
-```
+```text
 12. **Reindex QMD**: run `qmd --db .qmd/index.sqlite update && qmd --db .qmd/index.sqlite embed` (if QMD installed).
 ```
 

--- a/.claude/specs/qmd-integration/requirements.md
+++ b/.claude/specs/qmd-integration/requirements.md
@@ -1,0 +1,56 @@
+# QMD Integration — Requirements
+
+## Goal
+
+Replace the vault's grep-based search with QMD hybrid search (BM25 + vector + LLM reranking). QMD runs entirely on-device. Integration touches: MCP server config, skill rewrites, reindex hooks, and the timeline web viewer.
+
+## Functional Requirements
+
+### FR-1: QMD Installation & Index Setup
+- Install QMD globally (`npm install -g @tobilu/qmd`)
+- Create vault-local SQLite database at `.qmd/index.sqlite`
+- Register 4 collections: `wiki/`, `journal/`, `inbox/`, `.raw/articles/`
+- Add per-collection context descriptions for improved relevance
+- Initial index build: `qmd update && qmd embed`
+- Add `.qmd/` to `.gitignore`
+
+### FR-2: MCP Server Integration
+- Configure QMD as an MCP server in `.claude/settings.json`
+- Exposes `query`, `get`, `multi_get`, `status` as native Claude Code tools
+- Uses vault-local DB path via `--db` flag
+- Available in every Claude session automatically
+
+### FR-3: Skill Rewrites
+- `/wiki-query`: try QMD first, fall back to grep if QMD unavailable
+- `/superhuman`: try QMD first, fall back to grep if QMD unavailable
+- Both skills preserve existing behavior (hot.md first, citations, filing answers)
+- QMD replaces the grep + manual file read step, not the synthesis step
+
+### FR-4: Reindex Hooks
+- PostToolUse hook on Write/Edit: run `qmd update` (FTS5 only, fast)
+- End of `/autoingest`: run `qmd update && qmd embed` (batch vector computation)
+- End of `/wiki-ingest`: run `qmd update && qmd embed`
+- Hooks are no-ops if QMD is not installed (graceful degradation)
+
+### FR-5: Timeline Web Viewer Search
+- Add search box to the timeline viewer UI
+- Search queries hit QMD's HTTP transport server (localhost)
+- Results link to matching day nodes / wiki pages
+- QMD HTTP server starts alongside the dev/preview server
+
+## Non-Functional Requirements
+
+### NFR-1: Progressive Enhancement
+- QMD is never a hard dependency. All skills fall back to grep if QMD is unavailable.
+- Missing models, unbuilt index, or crashed server must not break any existing workflow.
+
+### NFR-2: Performance
+- `qmd update` (FTS5 rescan) should complete in <2s for the current vault size
+- `qmd embed` for a single new file should complete in <10s
+- Full embed for ~200 files: expect 5-15 minutes (one-time cost)
+- Viewer search latency: <500ms per query
+
+### NFR-3: Storage
+- Models: ~2.1GB in `~/.cache/qmd/models/` (shared across projects)
+- Index: vault-local `.qmd/index.sqlite` (estimated <50MB for current vault)
+- Both excluded from git

--- a/.claude/specs/qmd-integration/tasks.md
+++ b/.claude/specs/qmd-integration/tasks.md
@@ -1,0 +1,56 @@
+# QMD Integration — Tasks
+
+## Phase 1: Foundation (30 min)
+
+- [ ] Install QMD: `npm install -g @tobilu/qmd`
+- [ ] Add `.qmd/` to `.gitignore`
+- [ ] Create `scripts/setup-qmd.sh` with collection registration + context descriptions
+- [ ] Run setup script — register 4 collections, build initial index + embeddings
+- [ ] Verify: `qmd --db .qmd/index.sqlite status` shows all 4 collections
+- [ ] Verify: `qmd --db .qmd/index.sqlite query "Verity compliance"` returns relevant results
+
+## Phase 2: MCP Server (10 min)
+
+- [ ] Add QMD MCP server to `.claude/settings.json`
+- [ ] Verify: restart Claude session, confirm `qmd` MCP tools appear
+- [ ] Test: use `query` tool directly in conversation to search the vault
+
+## Phase 3: Skill Rewrites (1 hour)
+
+- [ ] Update `/wiki-query` SKILL.md:
+  - Add QMD query step in Standard mode (step 3)
+  - Add QMD query step in Deep mode (step 3)
+  - Add availability check + grep fallback
+  - Preserve hot.md-first pattern and citation format
+- [ ] Update `/superhuman` SKILL.md:
+  - Replace grep step with QMD query
+  - Add availability check + grep fallback
+  - Preserve LLM-ranking and citation format
+- [ ] Test `/wiki-query`: query about a known concept, verify QMD results used
+- [ ] Test `/superhuman`: query across journal + wiki, verify cross-collection results
+- [ ] Test fallback: temporarily rename .qmd/, verify skills fall back to grep
+
+## Phase 4: Reindex Hooks (20 min)
+
+- [ ] Add PostToolUse hook for Write/Edit → `qmd update` (FTS5 only)
+- [ ] Add `qmd update && qmd embed` step to autoingest SKILL.md (after timeline rebuild)
+- [ ] Add `qmd update && qmd embed` step to wiki-ingest SKILL.md (after log update)
+- [ ] Test: create a quicknote, verify it appears in QMD search within seconds
+- [ ] Test: run `/wiki-ingest` on a URL, verify new pages appear in QMD search
+
+## Phase 5: Timeline Viewer Search (2-3 hours)
+
+- [ ] Create or update serve script to start QMD HTTP server alongside Vite
+- [ ] Create `timeline/src/components/Search.tsx` — search box + results
+- [ ] Integrate Search into Timeline.tsx layout
+- [ ] Style search results (snippet highlighting, score badges, click-to-navigate)
+- [ ] Test: search for a term, verify results link to correct day nodes
+- [ ] Test: search for a wiki concept, verify cross-collection results
+
+## Verification
+
+- [ ] End-to-end: write a new wiki page → qmd update hook fires → search finds it immediately (FTS5)
+- [ ] End-to-end: run /autoingest → new files indexed + embedded → semantic search finds them
+- [ ] End-to-end: /superhuman query returns QMD-ranked results with citations
+- [ ] End-to-end: timeline viewer search returns results from all 4 collections
+- [ ] Graceful degradation: uninstall QMD → all skills still work via grep fallback


### PR DESCRIPTION
## Summary

- **QMD integration spec** (`.claude/specs/qmd-integration/`): Full requirements, design, and tasks for replacing grep-based vault search with QMD hybrid search (BM25 + vector + LLM reranking). 5 phases: setup, MCP server, skill rewrites, reindex hooks, timeline viewer search.
- **iCloud vault autoingest**: Extends the folder handler with `recursive`, `match`, and `exclude` fields to support syncing from iCloud Obsidian vault as an autoingest source.

## QMD Spec Decisions

| Decision | Choice |
|----------|--------|
| Collections | wiki + journal + inbox + .raw/articles |
| Integration | MCP server + skill rewrites |
| Reindex | PostToolUse hook for FTS5, batch embed at ingest end |
| Viewer search | QMD HTTP server alongside Vite |
| Fallback | Graceful degradation to grep |
| DB location | Vault-local .qmd/index.sqlite |

## Test plan

- [ ] Review spec files for completeness
- [ ] Verify autoingest folder handler changes don't break existing inbox/unsorted source
- [ ] Spec execution tracked in tasks.md checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated folder handler configuration documentation with support for recursive traversal, pattern matching, and folder exclusion options
  * Added comprehensive design, requirements, and implementation task documentation for new search integration capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->