### PR TITLE
feat(timeline-viewer): editorial layout with bulleted summaries and back button

### DIFF
--- a/timeline/index.html
+++ b/timeline/index.html
@@ -4,8 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Timeline</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,300..900,0..100,0..1;1,9..144,300..900,0..100,0..1&family=Instrument+Sans:ital,wght@0,400..700;1,400..700&family=JetBrains+Mono:ital,wght@0,400..700;1,400..700&display=swap"
+    />
   </head>
-  <body class="bg-zinc-950 text-zinc-100 min-h-screen">
+  <body class="bg-zinc-950 text-zinc-100 min-h-screen antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/timeline/src/components/DayNode.tsx
+++ b/timeline/src/components/DayNode.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
-import { getCategoryColors } from '../lib/colors';
-import { formatDate, formatCounts } from '../lib/format';
+import { getCategoryColors, getCategoryLabel } from '../lib/colors';
+import { dateParts, formatStats, splitSummary } from '../lib/format';
 import type { DayEntry } from '../types';
 
 interface DayNodeProps {
@@ -11,18 +11,93 @@ interface DayNodeProps {
   isSelected: boolean;
 }
 
-function DaySummary({ day, countLines }: { day: DayEntry; countLines: string[] }) {
+function DayCardContent({ day, dense = false }: { day: DayEntry; dense?: boolean }) {
+  const colors = getCategoryColors(day.dominant_category);
+  const { weekday, day: dayNum, month, year } = dateParts(day.date);
+  const { lead, body, bullets } = splitSummary(day.summary);
+  const stats = formatStats(day.counts, dense ? 3 : 5);
+  const hasContent = day.summary || stats.length > 0;
+
   return (
-    <>
-      {day.summary && (
-        <p className="text-sm text-zinc-300 leading-relaxed mb-2">{day.summary}</p>
+    <div className="flex flex-col gap-3">
+      <header className="flex items-start justify-between gap-4">
+        <div className="flex items-baseline gap-2.5">
+          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-zinc-500">
+            {weekday}
+          </span>
+          <span className="font-display text-2xl leading-none font-light text-zinc-100 tabular-nums">
+            {dayNum}
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-zinc-500">
+            {month} <span className="text-zinc-700">·</span> {year}
+          </span>
+        </div>
+        <span className={`inline-flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-eyebrow px-1.5 py-0.5 rounded-sm ${colors.bg} ${colors.text} border ${colors.border}`}>
+          <span className={`w-1 h-1 rounded-full ${colors.dot}`} />
+          {getCategoryLabel(day.dominant_category)}
+        </span>
+      </header>
+
+      {hasContent && <div className="hairline" />}
+
+      {day.summary ? (
+        <div className="space-y-2.5">
+          {lead && (
+            <h3 className="font-display text-[17px] leading-snug font-normal text-zinc-100 tracking-tight">
+              {lead}
+            </h3>
+          )}
+          {bullets.length > 0 ? (
+            <ul className="space-y-1.5">
+              {bullets.map((b, i) => (
+                <li key={i} className="flex gap-2 text-[13px] leading-relaxed text-zinc-300">
+                  <span className={`mt-[7px] h-1 w-1 shrink-0 rounded-full ${colors.dot} opacity-70`} />
+                  <div className="flex-1 min-w-0">
+                    {b.subItems ? (
+                      <>
+                        <span className="text-zinc-300">{b.subLead}</span>
+                        <ul className="mt-1 space-y-0.5">
+                          {b.subItems.slice(0, dense ? 3 : b.subItems.length).map((item, j) => (
+                            <li key={j} className="flex gap-1.5 text-[12px] text-zinc-400">
+                              <span className="text-zinc-600 shrink-0">›</span>
+                              <span className="flex-1">{item}</span>
+                            </li>
+                          ))}
+                          {dense && b.subItems.length > 3 && (
+                            <li className="text-[11px] text-zinc-600 font-mono uppercase tracking-wider ml-3.5">
+                              +{b.subItems.length - 3} more
+                            </li>
+                          )}
+                        </ul>
+                      </>
+                    ) : (
+                      <span>{b.text}</span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className={`text-[13px] leading-relaxed text-zinc-400 ${lead ? '' : 'font-display text-[15px] text-zinc-200 leading-snug'}`}>
+              {body}
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="text-[12px] text-zinc-600 italic font-display">Quiet day.</p>
       )}
-      <div className="flex flex-wrap gap-x-3 gap-y-0.5">
-        {countLines.map((line, i) => (
-          <span key={i} className="text-xs text-zinc-500">{line}</span>
-        ))}
-      </div>
-    </>
+
+      {stats.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 pt-1">
+          {stats.map((s) => (
+            <div key={s.key} className="stat-pill">
+              <span className="stat-pill-num">{s.value}</span>
+              <span className="stat-pill-label">{s.shortLabel}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -30,7 +105,6 @@ export default function DayNode({ day, side, collapsed, onSelect, isSelected }: 
   const [showTooltip, setShowTooltip] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const colors = getCategoryColors(day.dominant_category);
-  const countLines = formatCounts(day.counts);
 
   const handleMouseEnter = () => {
     timeoutRef.current = setTimeout(() => setShowTooltip(true), 200);
@@ -47,6 +121,7 @@ export default function DayNode({ day, side, collapsed, onSelect, isSelected }: 
         <button
           onClick={() => onSelect(day)}
           className={`w-3 h-3 rounded-full transition-all duration-300 ${colors.dot} ${isSelected ? 'ring-2 ring-white/40 scale-125' : 'hover:scale-125'}`}
+          aria-label={`Select ${day.date}`}
         />
       </div>
     );
@@ -54,32 +129,31 @@ export default function DayNode({ day, side, collapsed, onSelect, isSelected }: 
 
   return (
     <div
-      className={`relative flex items-center gap-6 py-4 ${side === 'left' ? 'flex-row-reverse' : 'flex-row'}`}
+      className={`relative flex items-stretch gap-6 py-4 ${side === 'left' ? 'flex-row-reverse' : 'flex-row'}`}
     >
       <div
-        className={`day-card flex-1 max-w-[calc(50%-2rem)] ${colors.border} ${colors.bg} ${side === 'left' ? 'ml-auto mr-8' : 'mr-auto ml-8'}`}
+        className={`day-card flex-1 max-w-[calc(50%-2rem)] ${isSelected ? 'day-card-selected' : 'border-zinc-800/70'} ${side === 'left' ? 'ml-auto mr-8' : 'mr-auto ml-8'}`}
         onClick={() => onSelect(day)}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <div className="flex items-center gap-2 mb-2">
-          <div className={`w-2.5 h-2.5 rounded-full ${colors.dot}`} />
-          <span className="text-xs text-zinc-500 tabular-nums">{formatDate(day.date)}</span>
-        </div>
-        <DaySummary day={day} countLines={countLines} />
+        <span className={`absolute top-0 ${side === 'left' ? 'right-0' : 'left-0'} h-full w-px ${colors.dot} opacity-50`} />
+        <DayCardContent day={day} />
       </div>
 
-      <div className="absolute left-1/2 -translate-x-1/2 z-10">
+      <div className="absolute left-1/2 -translate-x-1/2 z-10 top-1/2 -translate-y-1/2">
         <button
           onClick={() => onSelect(day)}
-          className={`w-[14px] h-[14px] rounded-full border-2 border-zinc-950 ${colors.dot} transition-transform duration-200 ${isSelected ? 'scale-150' : 'hover:scale-125'}`}
-        />
+          className={`relative w-[14px] h-[14px] rounded-full border-2 border-zinc-950 ${colors.dot} transition-transform duration-200 ${isSelected ? 'scale-150' : 'hover:scale-125'}`}
+          aria-label={`Select ${day.date}`}
+        >
+          <span className={`absolute inset-0 rounded-full ${colors.dot} opacity-50 animate-ping`} style={{ animationDuration: '3s' }} />
+        </button>
       </div>
 
       {showTooltip && (
-        <div className={`absolute z-40 w-72 bg-zinc-900 border border-zinc-700 rounded-lg p-3 shadow-xl ${side === 'left' ? 'right-[calc(50%+1.5rem)]' : 'left-[calc(50%+1.5rem)]'} top-1/2 -translate-y-1/2`}>
-          <p className="text-sm font-medium text-zinc-200 mb-1">{formatDate(day.date)}</p>
-          <DaySummary day={day} countLines={countLines} />
+        <div className={`absolute z-40 w-80 bg-zinc-900/95 backdrop-blur-sm border border-zinc-700/70 rounded-xl p-4 shadow-2xl ${side === 'left' ? 'right-[calc(50%+1.5rem)]' : 'left-[calc(50%+1.5rem)]'} top-1/2 -translate-y-1/2`}>
+          <DayCardContent day={day} dense />
         </div>
       )}
     </div>

--- a/timeline/src/components/DetailPanel.tsx
+++ b/timeline/src/components/DetailPanel.tsx
@@ -1,6 +1,7 @@
+import { useEffect } from 'react';
 import Markdown from 'react-markdown';
 import { getCategoryColors, getCategoryLabel } from '../lib/colors';
-import { formatDate, formatCounts } from '../lib/format';
+import { dateParts, formatStats, splitSummary } from '../lib/format';
 import type { DayEntry } from '../types';
 
 interface DetailPanelProps {
@@ -9,53 +10,160 @@ interface DetailPanelProps {
 }
 
 export default function DetailPanel({ day, onClose }: DetailPanelProps) {
+  useEffect(() => {
+    if (!day) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [day, onClose]);
+
   if (!day) return null;
 
   const colors = getCategoryColors(day.dominant_category);
-  const countLines = formatCounts(day.counts);
+  const { weekdayFull, day: dayNum, monthFull, year, weekday, month } = dateParts(day.date);
+  const { lead, body, bullets } = splitSummary(day.summary);
+  const stats = formatStats(day.counts, 8);
 
   return (
-    <div className="detail-panel w-[70%] p-8 pt-6">
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-semibold text-zinc-100 mb-1">{formatDate(day.date)}</h1>
-          <div className="flex items-center gap-2">
-            <span className={`inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full ${colors.bg} ${colors.text} border ${colors.border}`}>
-              <span className={`w-1.5 h-1.5 rounded-full ${colors.dot}`} />
-              {getCategoryLabel(day.dominant_category)}
-            </span>
-            {day.summary && (
-              <span className="text-sm text-zinc-500 italic">{day.summary}</span>
-            )}
-          </div>
-        </div>
+    <div className="detail-panel w-[70%]">
+      <div className="sticky top-0 z-10 bg-zinc-950/90 backdrop-blur-md border-b border-zinc-800/60 px-8 py-4 flex items-center justify-between">
         <button
           onClick={onClose}
-          className="text-zinc-500 hover:text-zinc-300 transition-colors p-1"
-          title="Close"
+          className="back-button group"
+          aria-label="Back to timeline"
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <svg className="back-arrow w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
           </svg>
+          <span>Back to timeline</span>
         </button>
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-[10px] uppercase tracking-eyebrow text-zinc-600">
+            ESC to close
+          </span>
+          <a
+            href={day.obsidian_uri}
+            className="inline-flex items-center gap-1.5 text-[11px] font-mono uppercase tracking-eyebrow text-sky-400 hover:text-sky-300 transition-colors"
+            title="Open in Obsidian"
+          >
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+            Obsidian
+          </a>
+        </div>
       </div>
 
-      <div className="flex flex-wrap gap-3 mb-6 pb-4 border-b border-zinc-800">
-        {countLines.map((line, i) => (
-          <span key={i} className="text-xs text-zinc-400 bg-zinc-900 px-2 py-1 rounded">{line}</span>
-        ))}
-        <a
-          href={day.obsidian_uri}
-          className="text-xs text-sky-400 hover:text-sky-300 transition-colors ml-auto"
-          title="Open in Obsidian"
-        >
-          Open in Obsidian
-        </a>
-      </div>
+      <div className="px-8 py-8 max-w-3xl">
+        <header className="mb-8">
+          <div className="flex items-baseline gap-3 mb-5">
+            <span className="font-mono text-[11px] uppercase tracking-eyebrow text-zinc-500">
+              {weekday}
+            </span>
+            <span className={`inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-eyebrow px-2 py-0.5 rounded-sm ${colors.bg} ${colors.text} border ${colors.border}`}>
+              <span className={`w-1 h-1 rounded-full ${colors.dot}`} />
+              {getCategoryLabel(day.dominant_category)}
+            </span>
+          </div>
 
-      <article className="prose prose-invert prose-sm max-w-none prose-headings:text-zinc-200 prose-headings:font-medium prose-p:text-zinc-300 prose-a:text-sky-400 prose-strong:text-zinc-200 prose-ul:text-zinc-400 prose-li:text-zinc-400 prose-code:text-amber-300 prose-code:bg-zinc-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-hr:border-zinc-800">
-        <Markdown>{day.body_md}</Markdown>
-      </article>
+          <h1 className="font-display text-5xl font-light text-zinc-50 leading-[0.95] tracking-tight mb-2">
+            <span className="tabular-nums">{dayNum}</span>
+            <span className="text-zinc-500 mx-2 font-light">/</span>
+            <span className="italic font-normal">{monthFull}</span>
+          </h1>
+          <p className="font-mono text-xs uppercase tracking-eyebrow text-zinc-500">
+            {weekdayFull} <span className="text-zinc-700 mx-1.5">·</span> {year}
+          </p>
+
+          {day.summary && (
+            <div className="mt-6 pt-6 border-t border-zinc-800/60">
+              <p className="font-mono text-[10px] uppercase tracking-eyebrow text-zinc-500 mb-2">
+                Précis
+              </p>
+              {lead && (
+                <h2 className="font-display text-xl font-normal text-zinc-100 leading-snug tracking-tight mb-4">
+                  {lead}
+                </h2>
+              )}
+              {bullets.length > 0 ? (
+                <ul className="space-y-2.5">
+                  {bullets.map((b, i) => (
+                    <li key={i} className="flex gap-3 text-[14px] leading-relaxed text-zinc-300">
+                      <span className={`mt-[9px] h-1 w-1 shrink-0 rounded-full ${colors.dot}`} />
+                      <div className="flex-1">
+                        {b.subItems ? (
+                          <>
+                            <span>{b.subLead}</span>
+                            <ul className="mt-1.5 ml-1 space-y-1 text-[13px] text-zinc-400">
+                              {b.subItems.map((item, j) => (
+                                <li key={j} className="flex gap-2">
+                                  <span className="text-zinc-600">›</span>
+                                  <span>{item}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </>
+                        ) : (
+                          b.text
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className={`${lead ? 'text-[14px] text-zinc-400' : 'font-display text-lg text-zinc-200'} leading-relaxed`}>
+                  {body}
+                </p>
+              )}
+            </div>
+          )}
+        </header>
+
+        {stats.length > 0 && (
+          <section className="mb-8">
+            <p className="font-mono text-[10px] uppercase tracking-eyebrow text-zinc-500 mb-3">
+              By the numbers
+            </p>
+            <div className="grid grid-cols-4 gap-px bg-zinc-800/60 border border-zinc-800/60 rounded-lg overflow-hidden">
+              {stats.map((s) => (
+                <div key={s.key} className="bg-zinc-950 px-4 py-3 flex flex-col gap-0.5">
+                  <span className="font-display text-2xl font-light text-zinc-100 tabular-nums leading-none">
+                    {s.value}
+                  </span>
+                  <span className="font-mono text-[9px] uppercase tracking-eyebrow text-zinc-500">
+                    {s.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section>
+          <div className="flex items-center gap-3 mb-5">
+            <p className="font-mono text-[10px] uppercase tracking-eyebrow text-zinc-500">
+              Day note
+            </p>
+            <div className="flex-1 h-px bg-zinc-800/60" />
+            <span className="font-mono text-[10px] text-zinc-600">{month} {dayNum}</span>
+          </div>
+          <article className="prose prose-invert prose-sm max-w-none
+            prose-headings:font-display prose-headings:font-normal prose-headings:tracking-tight prose-headings:text-zinc-100
+            prose-h1:text-2xl prose-h2:text-xl prose-h2:mt-8 prose-h2:mb-3 prose-h2:pb-2 prose-h2:border-b prose-h2:border-zinc-800/60
+            prose-h3:text-base prose-h3:font-sans prose-h3:uppercase prose-h3:tracking-eyebrow prose-h3:text-zinc-400 prose-h3:text-xs
+            prose-p:text-zinc-300 prose-p:leading-relaxed
+            prose-a:text-sky-400 prose-a:no-underline hover:prose-a:text-sky-300 hover:prose-a:underline
+            prose-strong:text-zinc-100 prose-strong:font-medium
+            prose-ul:text-zinc-300 prose-li:text-zinc-300 prose-li:marker:text-zinc-600
+            prose-code:text-amber-300 prose-code:bg-zinc-900 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:font-mono prose-code:text-[12px] prose-code:before:content-none prose-code:after:content-none
+            prose-hr:border-zinc-800/60
+            prose-blockquote:border-l-2 prose-blockquote:border-zinc-700 prose-blockquote:text-zinc-400 prose-blockquote:italic prose-blockquote:font-display">
+            <Markdown>{day.body_md}</Markdown>
+          </article>
+        </section>
+      </div>
     </div>
   );
 }

--- a/timeline/src/lib/format.ts
+++ b/timeline/src/lib/format.ts
@@ -33,6 +33,28 @@ export function dayGap(dateA: string, dateB: string): number {
   return a && b ? Math.abs(differenceInCalendarDays(a, b)) : 0;
 }
 
+export interface DateParts {
+  weekday: string;
+  weekdayFull: string;
+  day: string;
+  month: string;
+  monthFull: string;
+  year: string;
+}
+
+export function dateParts(dateStr: string): DateParts {
+  const d = safeParse(dateStr);
+  if (!d) return { weekday: '', weekdayFull: '', day: dateStr, month: '', monthFull: '', year: '' };
+  return {
+    weekday: format(d, 'EEE').toUpperCase(),
+    weekdayFull: format(d, 'EEEE'),
+    day: format(d, 'd'),
+    month: format(d, 'MMM').toUpperCase(),
+    monthFull: format(d, 'MMMM'),
+    year: format(d, 'yyyy'),
+  };
+}
+
 const COUNT_LABELS: Record<CountKey, string> = {
   journal_entries: 'journal entries',
   quicknotes: 'quicknotes',
@@ -46,10 +68,127 @@ const COUNT_LABELS: Record<CountKey, string> = {
   voice_memos: 'voice memos',
 };
 
+const COUNT_SHORT_LABELS: Record<CountKey, string> = {
+  journal_entries: 'journal',
+  quicknotes: 'notes',
+  ingests: 'ingests',
+  reminders_set: 'reminders',
+  reminders_completed: 'done',
+  git_commits: 'commits',
+  pages_created: 'created',
+  pages_updated: 'updated',
+  photos: 'photos',
+  voice_memos: 'voice',
+};
+
 export function formatCounts(counts: Partial<Record<CountKey, number>>): string[] {
   return Object.entries(counts)
     .filter(([, v]) => v != null && v > 0)
     .sort(([, a], [, b]) => (b ?? 0) - (a ?? 0))
     .slice(0, 5)
     .map(([key, value]) => `${value} ${COUNT_LABELS[key as CountKey] || key}`);
+}
+
+export interface StatEntry {
+  key: CountKey;
+  value: number;
+  label: string;
+  shortLabel: string;
+}
+
+export function formatStats(counts: Partial<Record<CountKey, number>>, limit = 5): StatEntry[] {
+  return Object.entries(counts)
+    .filter(([, v]) => v != null && v > 0)
+    .sort(([, a], [, b]) => (b ?? 0) - (a ?? 0))
+    .slice(0, limit)
+    .map(([key, value]) => ({
+      key: key as CountKey,
+      value: value as number,
+      label: COUNT_LABELS[key as CountKey] || key,
+      shortLabel: COUNT_SHORT_LABELS[key as CountKey] || key,
+    }));
+}
+
+export interface Bullet {
+  text: string;
+  subLead?: string;
+  subItems?: string[];
+}
+
+export interface SplitSummary {
+  lead: string | null;
+  body: string;
+  bullets: Bullet[];
+}
+
+// Split a string on a delimiter, ignoring occurrences inside parentheses.
+function splitOutsideParens(text: string, delim: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let buf = '';
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth = Math.max(0, depth - 1);
+    if (depth === 0 && text.substring(i, i + delim.length) === delim) {
+      parts.push(buf);
+      buf = '';
+      i += delim.length - 1;
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf) parts.push(buf);
+  return parts.map(s => s.trim()).filter(Boolean);
+}
+
+function cleanBullet(s: string): string {
+  return s.replace(/\.$/, '').replace(/^and\s+/i, '').trim();
+}
+
+// For long "covering/across/including X, Y, Z, and W" clauses, expand the list
+// into sub-items for readability.
+function expandListBullet(bullet: string): Bullet {
+  if (bullet.length < 120) return { text: bullet };
+  const match = bullet.match(/^(.+?\b(?:covering|across|including|spanning|from|via)\s+)(.+)$/i);
+  if (!match) return { text: bullet };
+  const [, lead, list] = match;
+  const items = splitOutsideParens(list, ', ').map(cleanBullet).filter(Boolean);
+  if (items.length >= 3) {
+    return { text: bullet, subLead: lead.trim().replace(/[,:]$/, ''), subItems: items };
+  }
+  return { text: bullet };
+}
+
+function toBullets(text: string): Bullet[] {
+  if (!text) return [];
+  let parts: string[] = [text];
+  parts = parts.flatMap(p => splitOutsideParens(p, '; '));
+  parts = parts.flatMap(p => splitOutsideParens(p, ' — '));
+  parts = parts.flatMap(p => p.split(/\.\s+(?=[A-Z])/g));
+  const cleaned = parts.map(cleanBullet).filter(Boolean);
+  if (cleaned.length < 2) return [];
+  return cleaned.map(expandListBullet);
+}
+
+// Split "Lead phrase: details..." into a headline + body, and break the body
+// into bullets where possible.
+export function splitSummary(summary: string): SplitSummary {
+  if (!summary) return { lead: null, body: '', bullets: [] };
+  let lead: string | null = null;
+  let body = summary;
+
+  const colonIdx = summary.indexOf(': ');
+  if (colonIdx > 0 && colonIdx <= 60) {
+    lead = summary.slice(0, colonIdx).trim();
+    body = summary.slice(colonIdx + 2).trim();
+  } else {
+    const dashIdx = summary.indexOf(' — ');
+    if (dashIdx > 0 && dashIdx <= 60) {
+      lead = summary.slice(0, dashIdx).trim();
+      body = summary.slice(dashIdx + 3).trim();
+    }
+  }
+
+  return { lead, body, bullets: toBullets(body) };
 }

--- a/timeline/src/styles/globals.css
+++ b/timeline/src/styles/globals.css
@@ -4,19 +4,33 @@
 
 @layer base {
   :root {
-    --spine-width: 2px;
+    --spine-width: 1px;
     --dot-size: 14px;
     --dot-size-lg: 18px;
     --transition-speed: 300ms;
   }
 
-  body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  html {
+    font-family: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif;
   }
 
-  /* Scrollbar styling */
+  body {
+    font-family: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif;
+    font-feature-settings: 'ss01', 'ss02', 'cv01';
+    background-image:
+      radial-gradient(ellipse 80% 50% at 50% -20%, rgba(120, 119, 198, 0.08), transparent),
+      radial-gradient(ellipse 60% 50% at 80% 110%, rgba(56, 189, 248, 0.05), transparent);
+    background-attachment: fixed;
+  }
+
+  .font-display {
+    font-optical-sizing: auto;
+    font-variation-settings: 'SOFT' 50, 'WONK' 0;
+  }
+
   ::-webkit-scrollbar {
     width: 6px;
+    height: 6px;
   }
   ::-webkit-scrollbar-track {
     background: transparent;
@@ -25,29 +39,88 @@
     background: rgb(63 63 70);
     border-radius: 3px;
   }
+  ::-webkit-scrollbar-thumb:hover {
+    background: rgb(82 82 91);
+  }
 }
 
 @layer components {
   .timeline-spine {
-    @apply absolute left-1/2 top-0 bottom-0 w-[2px] bg-zinc-800 -translate-x-1/2;
+    @apply absolute left-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-zinc-800 to-transparent -translate-x-1/2;
   }
 
   .timeline-spine-collapsed {
-    @apply absolute right-[15%] top-0 bottom-0 w-[2px] bg-zinc-800;
+    @apply absolute right-[15%] top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-zinc-800 to-transparent;
   }
 
   .day-card {
-    @apply relative bg-zinc-900 border border-zinc-800 rounded-lg p-4 max-w-md
-           transition-all duration-300 ease-out hover:border-zinc-600 hover:bg-zinc-900/80
-           cursor-pointer;
+    @apply relative border rounded-xl p-5 max-w-md cursor-pointer
+           transition-all duration-300 ease-out
+           backdrop-blur-sm
+           hover:border-zinc-600/80 hover:-translate-y-0.5;
+    background: linear-gradient(180deg, rgba(24, 24, 27, 0.6) 0%, rgba(9, 9, 11, 0.8) 100%);
+  }
+
+  .day-card:hover {
+    box-shadow: 0 8px 24px -8px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.02);
+  }
+
+  .day-card-selected {
+    @apply border-zinc-500;
+    box-shadow: 0 12px 32px -8px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.04);
   }
 
   .detail-panel {
-    @apply fixed top-0 left-0 h-full overflow-y-auto bg-zinc-950 border-r border-zinc-800
+    @apply fixed top-0 left-0 h-full overflow-y-auto bg-zinc-950/95 backdrop-blur-md
+           border-r border-zinc-800/60
            transition-all duration-300 ease-out;
+    background-image:
+      radial-gradient(ellipse 60% 40% at 0% 0%, rgba(120, 119, 198, 0.06), transparent);
   }
 
   .gap-marker {
-    @apply text-zinc-600 text-sm italic text-center py-4;
+    @apply text-zinc-600 font-mono text-xs tracking-widest uppercase text-center py-6 flex items-center justify-center gap-3;
+  }
+
+  .gap-marker::before,
+  .gap-marker::after {
+    content: '';
+    @apply h-px bg-zinc-800 flex-1 max-w-16;
+  }
+
+  .eyebrow {
+    @apply font-mono text-[10px] uppercase tracking-eyebrow text-zinc-500;
+  }
+
+  .stat-pill {
+    @apply flex items-baseline gap-1.5 px-2.5 py-1 rounded-md bg-zinc-900/60 border border-zinc-800/60;
+  }
+
+  .stat-pill-num {
+    @apply font-mono font-medium tabular-nums text-zinc-200 text-xs;
+  }
+
+  .stat-pill-label {
+    @apply text-[10px] text-zinc-500 uppercase tracking-wider;
+  }
+
+  .hairline {
+    @apply h-px bg-gradient-to-r from-transparent via-zinc-800 to-transparent;
+  }
+
+  .back-button {
+    @apply inline-flex items-center gap-2 text-xs font-mono uppercase tracking-eyebrow
+           text-zinc-400 hover:text-zinc-100
+           px-3 py-2 rounded-md border border-zinc-800 hover:border-zinc-600
+           bg-zinc-900/50 hover:bg-zinc-900
+           transition-all duration-200;
+  }
+
+  .back-button:hover .back-arrow {
+    transform: translateX(-2px);
+  }
+
+  .back-arrow {
+    @apply transition-transform duration-200;
   }
 }

--- a/timeline/tailwind.config.js
+++ b/timeline/tailwind.config.js
@@ -5,7 +5,16 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        display: ['Fraunces', 'ui-serif', 'Georgia', 'serif'],
+        sans: ['Instrument Sans', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+      },
+      letterSpacing: {
+        'eyebrow': '0.18em',
+      },
+    },
   },
   plugins: [
     require('@tailwindcss/typography'),


### PR DESCRIPTION
## Summary
- Redesigns the timeline web viewer with a refined **editorial aesthetic** — Fraunces serif for display, Instrument Sans for body, JetBrains Mono for eyebrows and tabular numerals. Distinctive without being generic.
- Rewrites day-card summaries from **single-paragraph blobs** into **bulleted lists** with paren-aware splitting on `; ` and ` — `; long list-style clauses (*"covering X, Y, Z..."*) auto-expand into indented sub-items with `›` markers.
- Adds a prominent **← Back to timeline** button (plus ESC shortcut) to the detail panel; ships a sticky header, large serif *19 / April* headline, a "By the numbers" stat grid, and refined prose styles for day-note markdown.

## What changed

| File | Change |
| --- | --- |
| [timeline/index.html](https://github.com/ckallum/timeline/blob/feat/timeline-viewer-polish/timeline/index.html) | Load Fraunces + Instrument Sans + JetBrains Mono from Google Fonts |
| [timeline/tailwind.config.js](https://github.com/ckallum/timeline/blob/feat/timeline-viewer-polish/timeline/tailwind.config.js) | Add `display`/`sans`/`mono` font families and `tracking-eyebrow` |
| [timeline/src/styles/globals.css](https://github.com/ckallum/timeline/blob/feat/timeline-viewer-polish/timeline/src/styles/globals.css) | New component classes: `day-card`, `back-button`, `stat-pill`, `eyebrow`, `hairline`; page-level radial gradient background |
| [timeline/src/lib/format.ts](https://github.com/ckallum/timeline/blob/feat/timeline-viewer-polish/timeline/src/lib/format.ts) | `dateParts()` for split date rendering; `splitSummary()` now returns `bullets` with optional nested `subLead`/`subItems`; paren-aware list splitter |
| [timeline/src/components/DayNode.tsx](https://github.com/ckallum/timeline/blob/feat/timeline-viewer-polish/timeline/src/components/DayNode.tsx) | Editorial card layout with serif day number, mono eyebrow, category chip, bulleted summary, nested sublists, stat pills, animated spine dot |
| [timeline/src/components/DetailPanel.tsx](https://github.com/ckallum/timeline/blob/feat/timeline-viewer-polish/timeline/src/components/DetailPanel.tsx) | Sticky back-button header, ESC shortcut, serif `19 / April` headline, Précis block with bulleted + nested lists, `By the numbers` grid, refined prose styling |

## Test plan
- [ ] `cd timeline && npm run dev` — verify card layout renders cleanly on first paint
- [ ] Confirm typography loads (Fraunces serif for day numbers, mono eyebrows)
- [ ] Click a card — back button is visible and returns to timeline
- [ ] ESC key closes detail panel
- [ ] Summaries with semicolons/em-dashes render as bullet lists
- [ ] Long "covering X, Y, Z..." summaries expand into nested sub-items
- [ ] `npm run build` succeeds and `npm run preview` serves without runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)