### PR TITLE
feat(timeline-viewer): DecksPicker popover for marp-rendered decks

### DIFF
--- a/.claude/.last-review
+++ b/.claude/.last-review
@@ -1,1 +1,1 @@
-{"diffHash":"47c5914ee970509b28e899c14935e930fce356e88ac1daf5a8a5e67e28fa5c11","reviewedAt":"2026-04-22T07:48:20.201Z","reviewer":"/review"}
+{"diffHash":"1cc0a5f561a5f91da73b95ad0d1584001f23faed1762933f74757af297d1a7a4","reviewedAt":"2026-04-22T08:54:05.223Z","reviewer":"code-reviewer"}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ wiki/**/*
 timeline/data/
 timeline/dist/
 timeline/node_modules/
+timeline/public/decks/
 
 # local config with potential secrets
 .claude/autoingest.config.json

--- a/timeline/src/components/DecksPicker.tsx
+++ b/timeline/src/components/DecksPicker.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Deck, DecksData } from '../types';
+
+export default function DecksPicker() {
+  const [decks, setDecks] = useState<Deck[] | null>(null);
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch('./data/decks.json')
+      .then(res => {
+        if (!res.ok) {
+          if (res.status === 404) {
+            setDecks([]);
+            return null;
+          }
+          throw new Error(`Failed to load decks: ${res.status}`);
+        }
+        return res.json();
+      })
+      .then((data: DecksData | null) => {
+        if (!data) return;
+        setDecks(Array.isArray(data.decks) ? data.decks : []);
+      })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : String(err));
+        setDecks([]);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('mousedown', onClick);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onClick);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  if (decks === null) return null;
+
+  const count = decks.length;
+
+  return (
+    <div ref={containerRef} className="fixed top-3 right-3 z-30">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-mono uppercase tracking-eyebrow bg-zinc-900/90 backdrop-blur-sm border border-zinc-700 rounded-md text-zinc-300 hover:text-zinc-100 hover:border-zinc-500 focus:outline-none focus:border-zinc-500"
+        aria-label="Open decks picker"
+        aria-expanded={open}
+      >
+        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <rect x="3" y="5" width="18" height="12" rx="1.5" />
+          <path d="M7 21h10" strokeLinecap="round" />
+        </svg>
+        Decks
+        <span className="text-zinc-500 tabular-nums">{count}</span>
+      </button>
+
+      {open && (
+        <div className="mt-2 w-80 bg-zinc-900/95 backdrop-blur-sm border border-zinc-800 rounded-md overflow-hidden shadow-2xl">
+          {error && (
+            <div className="px-3 py-2 text-xs text-red-400 border-b border-zinc-800">{error}</div>
+          )}
+          {count === 0 ? (
+            <div className="px-3 py-4 text-xs text-zinc-500">
+              No decks yet. Build one with <code className="text-amber-300">/marp</code>.
+            </div>
+          ) : (
+            <ul className="max-h-[70vh] overflow-y-auto">
+              {decks.map(deck => (
+                <li key={deck.slug} className="border-b border-zinc-800 last:border-b-0">
+                  <div className="px-3 py-2.5 hover:bg-zinc-800/60">
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="text-sm text-zinc-100 font-medium truncate">{deck.title}</span>
+                      {typeof deck.slides === 'number' && (
+                        <span className="text-[10px] text-zinc-500 tabular-nums shrink-0">
+                          {deck.slides} slides
+                        </span>
+                      )}
+                    </div>
+                    {deck.subtitle && (
+                      <div className="text-[11px] text-zinc-400 mt-0.5 line-clamp-2">{deck.subtitle}</div>
+                    )}
+                    <div className="flex items-center gap-3 mt-2">
+                      {deck.html && (
+                        <a
+                          href={`./${deck.html}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-[11px] font-mono uppercase tracking-eyebrow text-sky-400 hover:text-sky-300"
+                        >
+                          Open HTML →
+                        </a>
+                      )}
+                      {deck.pdf && (
+                        <a
+                          href={`./${deck.pdf}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-[11px] font-mono uppercase tracking-eyebrow text-zinc-400 hover:text-zinc-200"
+                        >
+                          PDF
+                        </a>
+                      )}
+                      {deck.updated && (
+                        <span className="ml-auto text-[10px] font-mono text-zinc-600">
+                          {deck.updated}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/timeline/src/components/Timeline.tsx
+++ b/timeline/src/components/Timeline.tsx
@@ -5,6 +5,7 @@ import YearNav from './YearNav';
 import EmptyState from './EmptyState';
 import Spinner from './Spinner';
 import Search from './Search';
+import DecksPicker from './DecksPicker';
 import { useTimelineData } from '../hooks/useTimelineData';
 import type { DayEntry } from '../types';
 import { dayGap, formatMonthYear, getYear } from '../lib/format';
@@ -160,6 +161,7 @@ export default function Timeline() {
   return (
     <div className="relative">
       <Search onNavigate={handleSearchNavigate} />
+      <DecksPicker />
       <YearNav years={years} onJump={handleJumpToYear} collapsed={collapsed} />
 
       {stickyHeader && !collapsed && (

--- a/timeline/src/types.ts
+++ b/timeline/src/types.ts
@@ -24,3 +24,20 @@ export interface TimelineData {
   days: DayEntry[];
   errors?: Array<{ file: string; error: string }>;
 }
+
+export interface Deck {
+  slug: string;
+  title: string;
+  subtitle?: string;
+  source: string;
+  html?: string;
+  pdf?: string;
+  slides?: number;
+  created?: string;
+  updated?: string;
+}
+
+export interface DecksData {
+  generated_at: string;
+  decks: Deck[];
+}


### PR DESCRIPTION
## Summary
- Adds `DecksPicker`, a popover in the viewer's top-right corner that lists decks produced by the `/marp` skill.
- Fetches `./data/decks.json` at mount; renders each deck with title, subtitle, slide count, Open-HTML and PDF links, and last-updated date.
- Handles a 404 response as the natural empty state ("No decks yet. Build one with `/marp`."), so the viewer works cleanly before any deck exists.
- Ignores `timeline/public/decks/` so the rendered HTML/PDF artifacts stay out of git.

## Pre-PR Gates
- **Test-presence**: 141 lines of code added, 0 new tests. The timeline-viewer project has no test runner configured (`package.json` scripts are `dev`, `build`, `preview` only). Verified via `npm run build` — `tsc -b` typechecks the new `Deck`/`DecksData` types and Vite builds cleanly.

## How It Works

```mermaid
flowchart LR
  marp[/marp skill] -->|writes| decksJson[public/data/decks.json]
  decksJson -->|fetch| picker[DecksPicker]
  picker -->|renders| popover[Decks popover]
  popover -->|links to| html[public/decks/*.html]
  popover -->|links to| pdf[public/decks/*.pdf]
```

The `/marp` skill produces decks into `timeline/public/decks/` and maintains a `decks.json` manifest in `public/data/`. `DecksPicker` reads that manifest and renders the navigation UI — it has no knowledge of marp itself beyond the JSON shape.

## Important Files
| File | Purpose |
|------|---------|
| `timeline/src/components/DecksPicker.tsx` | New popover component — fetch, click-outside/Escape dismiss, empty state, deck list |
| `timeline/src/components/Timeline.tsx` | Mounts `<DecksPicker />` next to `<Search />` |
| `timeline/src/types.ts` | Adds `Deck` and `DecksData` interfaces matching the `/marp` manifest shape |
| `.gitignore` | Excludes `timeline/public/decks/` (rendered artifacts) |

## Test Results
| Check | Result |
|-------|--------|
| `npm run build` (typecheck + vite build) | ✓ 505 modules transformed, no errors |

## Pre-Landing Review
No issues found. `code-reviewer` agent stamped at `.claude/.last-review`.

## Doc Completeness
- [x] Component file reads naturally without external doc
- [x] Type shape matches `/marp` skill's `decks.json` contract
- [x] Empty state tells the user how to populate it

🤖 Generated with [Claude Code](https://claude.com/claude-code)