### PR TITLE
chore(claude): reconcile skills and agents with calsuite@abe30a6

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: code-reviewer
 description: "Reviews staged git changes against CLAUDE.md conventions and codebase patterns. Returns PASS/BLOCKED verdict. Spawn with: @code-reviewer"
 model: sonnet
@@ -83,7 +83,7 @@ For each newly added path, identify the **nearest enclosing** `CLAUDE.md` (root 
 - **New environment variables or external dependencies** — code references a new env var or a new external service/integration, but no `CLAUDE.md` section listing env vars or external dependencies is updated.
 - **New specs** — files added under `.claude/specs/` with no mention in a `CLAUDE.md`'s project-structure / specs listing.
 
-Only consider **additions**. Modifications to existing files do not trigger this check.
+Bullets 1 (new modules/dirs) and 5 (new specs) only fire on file **additions** (`--diff-filter=A`). Bullets 2–4 (architectural changes, new patterns, new env vars / external deps) can fire on **modifications** too — adding `process.env.NEW_VAR` to an existing file or introducing a new helper inside an existing module both warrant a doc update without creating any new file. Use the staged file list from step 1 for those bullets, and the `--diff-filter=A` list for the structural-addition ones.
 
 Report each hit as an `info` finding with:
 - The new path that triggered it.

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: babysit-pr
 version: 1.0.0
 description: |

--- a/.claude/skills/context7/SKILL.md
+++ b/.claude/skills/context7/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: context7
 description: "Look up current, version-specific library documentation using Context7. Use proactively when working with libraries or explicitly via /context7."
 user-invocable: true

--- a/.claude/skills/customise/SKILL.md
+++ b/.claude/skills/customise/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: customise
 description: |
   customise a skill for this project, fork a skill locally, project-specific skill tweak,

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: debug
 version: 1.0.0
 description: |

--- a/.claude/skills/execute/SKILL.md
+++ b/.claude/skills/execute/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: execute
 version: 2.1.0
 description: |

--- a/.claude/skills/guardian/SKILL.md
+++ b/.claude/skills/guardian/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: guardian
 description: "Configure Guardian autonomous mode, switch modes, view audit log, and manage rules"
 user-invocable: true

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: learn
 version: 1.0.0
 description: |

--- a/.claude/skills/lint-rule-gen/SKILL.md
+++ b/.claude/skills/lint-rule-gen/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: lint-rule-gen
 version: 1.0.0
 description: |

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: new-spec
 description: |
   Scaffold a new spec directory with requirements.md, design.md, and tasks.md

--- a/.claude/skills/plan-ceo/SKILL.md
+++ b/.claude/skills/plan-ceo/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: plan-ceo
 version: 1.0.0
 description: |

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: plan
 version: 1.0.0
 description: |

--- a/.claude/skills/prevent/SKILL.md
+++ b/.claude/skills/prevent/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: prevent
 version: 1.0.0
 description: |

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: qa
 version: 1.0.0
 description: |

--- a/.claude/skills/qa/references/issue-taxonomy.md
+++ b/.claude/skills/qa/references/issue-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 ---
 
 # QA Issue Taxonomy

--- a/.claude/skills/qa/templates/qa-report-template.md
+++ b/.claude/skills/qa/templates/qa-report-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 ---
 
 # QA Report: {APP_NAME}

--- a/.claude/skills/receiving-pr-feedback/SKILL.md
+++ b/.claude/skills/receiving-pr-feedback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: receiving-pr-feedback
 version: 1.0.0
 description: |

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: retro
 version: 1.1.0
 description: |

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: review
 version: 1.1.0
 description: |

--- a/.claude/skills/review/checklist.md
+++ b/.claude/skills/review/checklist.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 ---
 
 # Pre-Landing Review Checklist

--- a/.claude/skills/review/greptile-triage.md
+++ b/.claude/skills/review/greptile-triage.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 ---
 
 # Greptile Comment Triage

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: session-start
 description: Load full project context — reads all .md files, specs, changelog, and git history to produce a prioritized project briefing
 user-invocable: true

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: ship
 version: 1.0.0
 description: |

--- a/.claude/skills/ship/pr-template.md
+++ b/.claude/skills/ship/pr-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 ---
 
 # PR Body Template

--- a/.claude/skills/strategic-compact/SKILL.md
+++ b/.claude/skills/strategic-compact/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: strategic-compact
 description: Hook-driven strategic compaction system. Tracks tool call count and suggests /compact at logical intervals (50 calls, then every 25) to preserve context through phase transitions.
 user-invocable: false

--- a/.claude/skills/sweep-issues/SKILL.md
+++ b/.claude/skills/sweep-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: sweep-issues
 version: 1.0.0
 description: |

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@f4ec704
+_origin: calsuite@abe30a6
 name: worktrees
 version: 1.0.0
 description: |


### PR DESCRIPTION
## Summary
- Bumps `_origin` across all skills and the `code-reviewer` agent from calsuite@f4ec704 → abe30a6
- Single substantive change: `code-reviewer` Doc Completeness checklist now also fires on modifications (not just additions) for env-var / new-pattern / architectural-change bullets

## Test plan
- [ ] Spot-check no project-customised skills got overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)