### PR TITLE
chore(claude): sync calsuite v2.23 — vocabulary, grilling, AFK/HITL

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: code-reviewer
 description: "Reviews staged git changes against CLAUDE.md conventions and codebase patterns. Returns PASS/BLOCKED verdict. Spawn with: @code-reviewer"
 model: sonnet

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: code-reviewer
 description: "Reviews staged git changes against CLAUDE.md conventions and codebase patterns. Returns PASS/BLOCKED verdict. Spawn with: @code-reviewer"
 model: sonnet

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: babysit-pr
 version: 1.0.0
 description: |

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: babysit-pr
 version: 1.0.0
 description: |

--- a/.claude/skills/context7/SKILL.md
+++ b/.claude/skills/context7/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: context7
 description: "Look up current, version-specific library documentation using Context7. Use proactively when working with libraries or explicitly via /context7."
 user-invocable: true

--- a/.claude/skills/context7/SKILL.md
+++ b/.claude/skills/context7/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: context7
 description: "Look up current, version-specific library documentation using Context7. Use proactively when working with libraries or explicitly via /context7."
 user-invocable: true

--- a/.claude/skills/customise/SKILL.md
+++ b/.claude/skills/customise/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: customise
 description: |
   customise a skill for this project, fork a skill locally, project-specific skill tweak,

--- a/.claude/skills/customise/SKILL.md
+++ b/.claude/skills/customise/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: customise
 description: |
   customise a skill for this project, fork a skill locally, project-specific skill tweak,

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,11 +1,13 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@03bb002
 name: debug
 version: 1.0.0
 description: |
   debug this, fix this bug, why is this failing, investigate error, trace the issue,
   something is broken, test failure, systematic debugging, diagnose, root cause.
-  Four-phase systematic debugging: investigate → analyze patterns → hypothesis test → fix.
+  Four-phase systematic debugging built around a fast, deterministic feedback loop:
+  Phase 1 build the loop, Phase 2 analyze patterns, Phase 3 test hypotheses, Phase 4 implement fix.
+  The feedback loop IS the skill — every later phase just consumes its signal.
   Parallel investigation for independent failures.
 argument-hint: [error-description]
 allowed-tools:
@@ -23,7 +25,13 @@ allowed-tools:
 
 Four mandatory phases. Do not skip ahead to fixing — understand first.
 
-## Phase 1: Investigate
+## Domain awareness (before Phase 1)
+
+If the repo has a `CONTEXT.md` (or a `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files), read it for the area you're debugging — getting the right mental model of the modules in play often shortens Phase 1 dramatically. If `docs/adr/` exists and an ADR covers the area, read it: many "weird" behaviors are deliberate decisions an ADR explains, and the bug is somewhere else.
+
+> **Phase 1 IS the skill.** A fast, deterministic, agent-runnable pass/fail signal for the bug is the difference between debugging and guessing. Everything in Phases 2–4 just consumes that signal. Spend disproportionate effort here. Be aggressive. Be creative. Refuse to give up.
+
+## Phase 1: Build a feedback loop
 
 ### Read the error carefully
 
@@ -32,23 +40,50 @@ Don't skim. Read the full error output, stack trace, and surrounding logs. Extra
 - **Where** it failed (file, line, function)
 - **When** it started failing (recent change? always broken?)
 
-### Reproduce consistently
+### Construct a loop — try these in roughly this order
+
+1. **Failing test** at whatever seam reaches the bug — unit, integration, e2e.
+2. **Curl / HTTP script** against a running dev server.
+3. **CLI invocation** with a fixture input, diffing stdout against a known-good snapshot.
+4. **Headless browser script** (Playwright / Puppeteer) — drives the UI, asserts on DOM/console/network.
+5. **Replay a captured trace.** Save a real network request / payload / event log to disk; replay it through the code path in isolation.
+6. **Throwaway harness.** Spin up a minimal subset of the system (one service, mocked deps) that exercises the bug code path with a single function call.
+7. **Property / fuzz loop.** If the bug is "sometimes wrong output", run 1000 random inputs and look for the failure mode.
+8. **Bisection harness.** If the bug appeared between two known states (commit, dataset, version), automate "boot at state X, check, repeat" so you can `git bisect run` it.
+9. **Differential loop.** Run the same input through old-version vs new-version (or two configs) and diff outputs.
+10. **HITL bash script.** Last resort. If a human must click, drive the loop with a script and capture output — keep the loop structured even when it's not headless.
 
 ```bash
 # Run the failing command/test
 <reproduce command>
 ```
 
-If it doesn't reproduce, it's likely a race condition, environment issue, or flaky test. Investigate those vectors specifically.
+### Iterate on the loop itself
 
-### Check recent changes
+Treat the loop as a product. Once you have *a* loop, ask:
+
+- Can I make it faster? (Cache setup, skip unrelated init, narrow the test scope.)
+- Can I make the signal sharper? (Assert on the specific symptom, not "didn't crash".)
+- Can I make it more deterministic? (Pin time, seed RNG, isolate filesystem, freeze network.)
+
+A 30-second flaky loop is barely better than no loop. A 2-second deterministic loop is a debugging superpower.
+
+### Non-deterministic bugs
+
+The goal is not a clean repro but a **higher reproduction rate**. Loop the trigger 100×, parallelize, add stress, narrow timing windows, inject sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate until it's debuggable.
+
+### Check recent changes (still relevant)
 
 ```bash
 git log --oneline -10
 git diff HEAD~3 --stat
 ```
 
-Did a recent commit touch the failing area? If so, read that diff first.
+Did a recent commit touch the failing area? Use that to inform Phase 3 hypothesis ranking, not as a substitute for the loop.
+
+### When you genuinely cannot build a loop
+
+Stop and say so explicitly. List what you tried. Ask the user for: (a) access to whatever environment reproduces it, (b) a captured artifact (HAR file, log dump, core dump, screen recording with timestamps), or (c) permission to add temporary production instrumentation. Do **not** proceed to hypothesize without a loop — guessing without a signal wastes more time than building the loop ever would.
 
 ### Gather evidence in multi-component systems
 
@@ -57,7 +92,9 @@ If the failure spans multiple components, trace the data flow:
 2. What transformations happen?
 3. Where does the output diverge from expected?
 
-Add temporary logging if needed to narrow down the boundary.
+Add temporary logging if needed to narrow down the boundary — but tag every log with a unique prefix (e.g. `[DEBUG-a4f2]`) so cleanup at the end is a single grep.
+
+**Do not proceed to Phase 2 until you have a loop you believe in.**
 
 ## Phase 2: Pattern Analysis
 
@@ -171,7 +208,7 @@ Rules for parallel dispatch:
 
 ## Gotchas
 
-- **Reproduce FIRST.** If you can't reproduce it, you can't verify the fix. Don't guess.
+- **Build a loop FIRST.** Without a fast pass/fail signal you cannot verify any fix. Don't guess. Reproduction is item 1 of the 10-tactic ladder, not the headline — the headline is "any deterministic signal".
 - **Check the test, not just the code.** Sometimes the test itself is wrong — asserting the wrong thing, using stale fixtures, or having a race condition.
 - **Environment differences matter.** CI vs local, Node version, env vars, database state. Ask if the failure is environment-specific.
 - **Flaky tests need special treatment.** If it fails intermittently, it's likely timing, ordering, or shared state. Run it 5x in a row to confirm.

--- a/.claude/skills/execute/SKILL.md
+++ b/.claude/skills/execute/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@03bb002
 name: execute
 version: 2.1.0
 description: |
@@ -25,6 +25,18 @@ allowed-tools:
 # Execute
 
 Flexible execution skill with three modes plus a parallel multi-pane launcher. All modes share the same execution engine — the only difference is how tasks are sourced and what the compliance reviewer checks against.
+
+## AFK vs HITL handling (shared)
+
+If the source task is labeled **AFK** (e.g. issue carries the `afk` label, or the spec/conversation marks it AFK), proceed end-to-end through the execution loop without pausing for confirmation between phases — that's what AFK means. If labeled **HITL**, the implementer pauses at each decision point and asks via AskUserQuestion before proceeding. Default when unlabeled: behave as HITL — only escalate to AFK behavior when explicitly marked or when the user is running under `/guardian mode autonomous`.
+
+## Domain awareness (shared, runs before any mode)
+
+If the repo has a `CONTEXT.md` (or a `CONTEXT-MAP.md` at the root pointing to per-module `CONTEXT.md` files), read it. **Use its vocabulary verbatim** in commit messages, test names, function/variable names, PR descriptions, and any user-facing text. The glossary is the project's source of truth for naming — drift defeats the point.
+
+If `docs/adr/` (or `<context>/docs/adr/`) exists and contains ADRs touching the area you're modifying, read them. Do not implement changes that contradict an accepted ADR without first surfacing the conflict to the user.
+
+Pass any relevant `CONTEXT.md` excerpts and ADR references into the implementer-agent prompt as part of `COMPLIANCE_REFERENCE` so the agent uses the same vocabulary.
 
 ```
 /execute                              → RAW mode   (execute from conversation context)

--- a/.claude/skills/guardian/SKILL.md
+++ b/.claude/skills/guardian/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@03bb002
 name: guardian
 description: "Configure Guardian autonomous mode, switch modes, view audit log, and manage rules"
 user-invocable: true
@@ -26,9 +26,11 @@ Switch Guardian's operating mode:
 5. Report what changed
 
 **Modes:**
-- **autonomous** — Broad permissions, guardian blocks only dangerous ops. Best for unattended work.
-- **supervised** — Read-only tools + safe git. Good for review/exploration sessions.
+- **autonomous** (alias: **AFK**) — Broad permissions, guardian blocks only dangerous ops. Best for unattended work — work that can run end-to-end without human input.
+- **supervised** (alias: **HITL**) — Read-only tools + safe git. Human-in-the-loop work where the user wants to approve each meaningful action.
 - **lockdown** — Minimal read-only access. For auditing or untrusted environments.
+
+**AFK vs HITL is the same axis as autonomous vs supervised.** The aliases exist because `/sweep-issues` (labelling) and `/execute` (running labelled work) use AFK/HITL — those labels map directly onto these modes when an agent picks up the work.
 
 ### `log [N]`
 

--- a/.claude/skills/improve-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-architecture/LANGUAGE.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 ---
 
 # Architectural Language

--- a/.claude/skills/improve-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-architecture/LANGUAGE.md
@@ -1,0 +1,59 @@
+---
+_origin: calsuite@ca49d29
+---
+
+# Architectural Language
+
+Shared vocabulary for every suggestion `/improve-architecture` makes. Use these terms exactly — don't substitute "component", "service", "API", "layer", or "boundary." Consistent language is the whole point: the user reads many audits over the lifetime of the codebase, and drift makes them harder to compare.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout's original framing): rewards padding the implementation with dead code. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"** as a synonym for seam: overloaded with DDD's bounded context. Say **seam** or **interface**.
+- **"Layer"** for module: too horizontal — modules can span layers (a vertical slice).
+- **"Abstraction"** for interface: too vague. Specify *what kind* of abstraction — interface, seam, adapter.

--- a/.claude/skills/improve-architecture/SKILL.md
+++ b/.claude/skills/improve-architecture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: improve-architecture
 version: 1.0.0
 description: |
@@ -124,7 +124,11 @@ Once the user picks a candidate, drop into a `/plan --grill`-style conversation.
 
 - **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` right there using the format below. Same discipline as `/plan --grill`.
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` inline.
-- **User rejects the candidate with a load-bearing reason?** Offer an ADR (at `docs/adr/NNNN-kebab-title.md`) **only if all three ADR criteria apply** — hard to reverse, surprising without context, real trade-off. Frame as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"* If the rejection doesn't meet all three (e.g. ephemeral "not worth it right now", or self-evident reasoning), skip the ADR and instead let `/sweep-issues` write a `.out-of-scope/<slug>.md` rejection record — the lighter-weight knowledge base.
+- **User rejects the candidate?** Persist the rejection **immediately, here, at rejection time** — don't defer to `/sweep-issues` (it may never run, and the next audit will re-suggest the same candidate). Two paths:
+  1. **Durable reason that meets all three ADR criteria** (hard to reverse, surprising without context, real trade-off): write `docs/adr/NNNN-kebab-title.md` now using the format below. Frame the offer as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"*
+  2. **Durable reason that doesn't meet all three** (e.g. "we'd revisit if we add multi-tenancy"): write `.out-of-scope/<kebab-slug>.md` now (format documented in `/sweep-issues` SKILL.md — `slug`, `rejected`, `related-issues` frontmatter, plus "Why we rejected it" and "What would change our minds" body sections). The next audit reads this and skips the candidate.
+
+  Only skip persistence entirely if the user explicitly marks the rejection **ephemeral** (e.g. "not worth it right now", "ask me again next quarter") — those don't need durable records because the reasoning won't apply later.
 
 ### `CONTEXT.md` format (when adding terms inline)
 

--- a/.claude/skills/improve-architecture/SKILL.md
+++ b/.claude/skills/improve-architecture/SKILL.md
@@ -1,0 +1,201 @@
+---
+_origin: calsuite@ca49d29
+name: improve-architecture
+version: 1.0.0
+description: |
+  improve architecture, codebase health check, find refactor opportunities, identify shallow modules,
+  deepen this code, ball of mud rescue, ai navigability audit, codebase entropy review,
+  proactive refactor pass, find seams, surface architectural friction.
+  Periodic codebase-wide review that finds shallow modules and proposes deepening opportunities —
+  refactors that turn shallow modules into deep ones for testability and AI-navigability.
+  Informed by CONTEXT.md (domain) and docs/adr/ (locked-in decisions).
+user-invocable: true
+argument-hint: "[path-or-module] [--candidates-only]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Agent
+  - AskUserQuestion
+  - Edit
+  - Write
+---
+
+# /improve-architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The goal is testability and AI-navigability: a codebase a fresh agent can navigate quickly, with bugs concentrated in one place, not scattered.
+
+Run periodically — every few weeks, or when the codebase starts to feel like a ball of mud. Pairs with `/simplify` (per-change cleanup) and `/review` (pre-merge) — `/improve-architecture` is the **codebase-wide health check** the others don't do.
+
+## Vocabulary
+
+This skill uses a fixed architectural vocabulary. Read [LANGUAGE.md](./LANGUAGE.md) **before generating any suggestions** and use these terms exactly. Drift to "component", "service", "API", "boundary", "layer", or "abstraction" defeats the point of having shared language. Quick reference:
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know: types, invariants, ordering, error modes, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface. **Deep** = lots of behaviour behind a small interface. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place.
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (full list in LANGUAGE.md):
+
+- **Deletion test:** imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+## Arguments
+
+- `/improve-architecture` — full codebase pass.
+- `/improve-architecture <path>` — restrict the audit to a path or module (e.g. `/improve-architecture src/billing/`).
+- `--candidates-only` — present the numbered list of deepening opportunities and stop. Don't drop into the grilling loop.
+
+## Process
+
+### Step 1: Read the project's domain artifacts
+
+Before exploring code, load context:
+
+- **`CONTEXT.md`** at the repo root (or `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files). The domain glossary names good seams — refactors that align with domain boundaries are worth more than ones that cut across them. If no `CONTEXT.md` exists, that itself is informative — note it; you may surface it as a candidate ("the codebase lacks a domain glossary, propose creating one").
+- **`docs/adr/`** (or `<context>/docs/adr/`) — read every ADR touching the area you'll audit. Don't propose refactors that contradict an accepted ADR unless the friction is real enough to warrant revisiting it (in which case mark the suggestion `contradicts ADR-NNNN — but worth reopening because…`).
+- **`.out-of-scope/`** — if it exists, read prior rejections (written by `/sweep-issues` when an enhancement is closed `wontfix`). Don't re-surface candidates already rejected for durable reasons. If a prior rejection seems wrong now because conditions changed, surface that reasoning rather than silently re-suggesting.
+
+### Step 2: Explore
+
+Dispatch an `Explore` agent to walk the codebase (or the path argument if scoped):
+
+```text
+prompt: "Walk the codebase at <path or repo root>. Read CLAUDE.md and CONTEXT.md if they exist.
+
+Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+- Are there pass-through modules that just forward calls (failing the deletion test)?
+
+For each spot of friction, capture: file/module path, what's friction-y, an initial hypothesis about whether deepening would help. Don't propose solutions yet — just report observations.
+
+Return a structured list of friction observations grouped by area."
+description: "Architectural friction scan"
+```
+
+Use Grep / Glob yourself to verify a few of the agent's claims before passing them through.
+
+### Step 3: Apply the deletion test
+
+For every candidate the explore agent flagged as a shallow module, apply the **deletion test**:
+
+> Imagine deleting this module. Does complexity vanish? Or does it reappear across N callers?
+
+- **Vanishes** → the module was a pass-through, doesn't pay its way. Strong deepen-or-inline candidate.
+- **Reappears across many callers** → the module is earning its keep, even if its current interface is awkward. Probably keep, possibly redesign the interface.
+- **Reappears in one caller** → consider inlining; one-caller modules rarely earn their interface tax.
+
+This is the most important filter — most "shallow" complaints are just preferences. The deletion test is a real argument.
+
+### Step 4: Present candidates
+
+Present a numbered list of deepening opportunities. For each:
+
+- **Files** — which files / modules are involved.
+- **Problem** — why the current architecture causes friction (in vocabulary terms — depth, leverage, locality, seam).
+- **Solution** — plain-English description of the proposed deepening. Don't propose a concrete interface yet.
+- **Benefits** — explained in terms of locality and leverage, plus how tests would improve. Reference the deletion test outcome.
+- **Risk / cost** — what would the refactor touch, and roughly how big.
+- **ADR conflicts** — flag any contradiction with existing ADRs.
+
+Use `CONTEXT.md` vocabulary for **domain** ("the Order intake module", not "the FooBarHandler"), and LANGUAGE.md vocabulary for **architecture** ("shallow seam", not "thin abstraction layer").
+
+If `--candidates-only` is set, stop here.
+
+Otherwise ask the user via AskUserQuestion: *"Which of these would you like to explore? A) #N B) #M C) None — close the audit"*.
+
+### Step 5: Grilling loop (per chosen candidate)
+
+Once the user picks a candidate, drop into a `/plan --grill`-style conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+**Side effects happen inline as decisions crystallize:**
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` right there using the format below. Same discipline as `/plan --grill`.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` inline.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR (at `docs/adr/NNNN-kebab-title.md`) **only if all three ADR criteria apply** — hard to reverse, surprising without context, real trade-off. Frame as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"* If the rejection doesn't meet all three (e.g. ephemeral "not worth it right now", or self-evident reasoning), skip the ADR and instead let `/sweep-issues` write a `.out-of-scope/<slug>.md` rejection record — the lighter-weight knowledge base.
+
+### `CONTEXT.md` format (when adding terms inline)
+
+```md
+**{Term}**:
+{One-sentence definition.}
+_Avoid_: {alias 1}, {alias 2}
+```
+
+Be opinionated, one canonical word per concept. Group under `## Language`, with `## Relationships`, `## Example dialogue`, and `## Flagged ambiguities` sections. Domain-only — no general programming concepts.
+
+### ADR format (at `docs/adr/NNNN-kebab-title.md`)
+
+```md
+# ADR-{NNNN}: {Verb-led title}
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+
+## Context
+{What forced the decision.}
+
+## Decision
+{What we decided.}
+
+## Consequences
+**Positive:** {what gets easier}
+**Negative:** {what gets harder}
+
+## Alternatives considered
+- **{Alternative}** — rejected because {reason}
+```
+
+Filename zero-padded sequential, verb-led title. Immutable once accepted — supersede with a new ADR rather than editing.
+- **User accepts the candidate and wants to implement?** Stop here — do **not** start coding inside `/improve-architecture`. Hand off: *"Run `/plan review` on this candidate, then `/execute`. I'll keep audit notes in CONTEXT.md / docs/adr/."* The skill is a surfacing-and-deciding tool, not an implementation tool.
+
+### Step 6: Write audit notes
+
+After the grilling loop, write a short audit summary to `.context/architecture-audits/YYYY-MM-DD.md`:
+
+```markdown
+# Architecture audit — YYYY-MM-DD
+
+Scope: <full codebase | path argument>
+
+## Candidates surfaced
+1. **<name>** — <one-line problem> — <decision: deepen / defer / rejected via ADR-NNNN>
+2. ...
+
+## Decisions
+- <bullet per resolved candidate>
+
+## CONTEXT.md updates
+- Added term: <term> — <reason>
+- Sharpened term: <term> — <reason>
+
+## ADRs written
+- ADR-NNNN: <title>
+
+## Next steps
+- /plan review <candidate slug>
+- /execute spec <slug>
+```
+
+This gives the next audit (in a few weeks) a starting point and prevents re-litigating the same candidates.
+
+## Gotchas
+
+- **Don't propose interfaces in Step 4.** Wait for the user to pick a candidate. Proposing concrete interfaces upfront is wasted work — most candidates won't be picked.
+- **Use the deletion test, not feel.** "This feels too shallow" is not a finding. "Deleting this module would push complexity into 5 callers, none of which would benefit from owning that complexity" is.
+- **Don't re-litigate ADRs unprompted.** If a candidate contradicts an ADR and the friction isn't severe, drop it silently. Only surface ADR-contradicting candidates when the friction is real and worth a discussion.
+- **Stay codebase-wide unless scoped.** This is the proactive health check — `/simplify` already covers per-change cleanup. If the user wants a focused review, they'll pass a path argument.
+- **The skill is read-and-decide, not write-and-implement.** When a candidate is approved, hand off to `/plan review` → `/execute`. Don't refactor inside this skill.
+- **AFK / HITL marking on follow-up issues.** When approved candidates spawn issues (via `/sweep-issues`), tag them AFK (clearly-spec'd refactor) or HITL (needs design decision) per the standard convention.

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@03bb002
 name: learn
 version: 1.0.0
 description: |
@@ -21,6 +21,18 @@ allowed-tools:
 # /learn — Cross-Session Learnings
 
 Durable memory for *this project*. Unlike `memory/` (which is about the user), `.context/learnings/` is about the *codebase* — patterns that worked, pitfalls encountered, preferences confirmed. Claude reads these at session start (via `/session-start`) and appends to them whenever something non-obvious surfaces.
+
+## Learnings vs ADRs vs CONTEXT.md
+
+Three sibling artifacts, three different purposes — pick the right one before saving:
+
+| Artifact | Scope | When |
+|---|---|---|
+| **Learning** (`.context/learnings/<slug>.md`) | Project-specific patterns, pitfalls, preferences | Non-obvious fact you want next session to remember |
+| **CONTEXT.md term** | Domain vocabulary | A new domain term was resolved or sharpened during the conversation |
+| **ADR** (`docs/adr/NNNN-*.md`) | Architectural decisions that are hard to reverse | A real trade-off was made and a future reader will wonder "why" |
+
+If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR at `docs/adr/NNNN-kebab-title.md`. ADRs commit to the repo and survive across teams in a way learnings don't. Learnings are for everything else: smaller-scale durable facts that don't merit either.
 
 ## Storage
 

--- a/.claude/skills/lint-rule-gen/SKILL.md
+++ b/.claude/skills/lint-rule-gen/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: lint-rule-gen
 version: 1.0.0
 description: |

--- a/.claude/skills/lint-rule-gen/SKILL.md
+++ b/.claude/skills/lint-rule-gen/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: lint-rule-gen
 version: 1.0.0
 description: |

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: new-spec
 description: |
   Scaffold a new spec directory with requirements.md, design.md, and tasks.md

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: new-spec
 description: |
   Scaffold a new spec directory with requirements.md, design.md, and tasks.md

--- a/.claude/skills/plan-ceo/SKILL.md
+++ b/.claude/skills/plan-ceo/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: plan-ceo
 version: 1.0.0
 description: |

--- a/.claude/skills/plan-ceo/SKILL.md
+++ b/.claude/skills/plan-ceo/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: plan-ceo
 version: 1.0.0
 description: |

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@03bb002
 name: plan
 version: 1.0.0
 description: |
@@ -9,7 +9,7 @@ description: |
   Four modes: INTERVIEW (surface edge cases, write spec), BRAINSTORM (explore design),
   REVIEW (lock in architecture, data flow, edge cases, tests),
   VISUALIZE (diagram-based design validation, bug shakeout).
-argument-hint: "[mode] [spec-path] [--lifecycle]"
+argument-hint: "[mode] [spec-path] [--lifecycle] [--grill]"
 allowed-tools:
   - Read
   - Write
@@ -26,12 +26,76 @@ allowed-tools:
 
 Consolidated planning skill. Start here before writing code.
 
+## Domain awareness (shared)
+
+Before any mode runs, scan for the project's domain artifacts:
+
+- **`CONTEXT.md`** at the repo root (or `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files) — the domain glossary. If present, read it and **use its vocabulary verbatim** in spec text, interview questions, diagrams, and review findings. Don't drift to synonyms; don't rewrite "Order intake module" as "the order service." When the conversation resolves a new term or sharpens a fuzzy one, offer to update `CONTEXT.md` inline.
+- **`docs/adr/`** (or `<context>/docs/adr/` in multi-context repos) — read any ADRs in the area being touched and respect them. Don't re-litigate decisions an ADR already locked in.
+- **No artifacts yet?** Don't scaffold them empty. Create `CONTEXT.md` lazily when the first term is resolved; create an ADR only when a decision meets **all three** criteria (hard to reverse, surprising without context, result of a real trade-off). Use the formats below.
+
+When `--grill` mode is active (see below), this discipline tightens: grill mode **must** challenge user terms against `CONTEXT.md` and propose ADRs for load-bearing irreversible decisions surfaced during the interview.
+
+### `CONTEXT.md` format (write inline as terms resolve)
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**{Term}**:
+{One-sentence definition. What it IS, not what it does.}
+_Avoid_: {alias 1}, {alias 2}
+
+## Relationships
+
+- A **{Term A}** {verb} one or more **{Term B}**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**…"
+> **Domain expert:** "An **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "{ambiguous term}" was used to mean both **{Term A}** and **{Term B}** — resolved: distinct concepts.
+```
+
+Be opinionated (one canonical word per concept; aliases under `_Avoid_`). Domain-only — general programming concepts don't belong. One-sentence definitions. Multi-context repos use `CONTEXT-MAP.md` at root pointing to per-module `CONTEXT.md` files.
+
+### ADR format (write at `docs/adr/NNNN-kebab-title.md`)
+
+```md
+# ADR-{NNNN}: {Verb-led title}
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+
+## Context
+{What forced the decision. 2-5 sentences.}
+
+## Decision
+{What we decided.}
+
+## Consequences
+**Positive:** {what gets easier}
+**Negative:** {what gets harder}
+
+## Alternatives considered
+- **{Alternative}** — rejected because {specific reason}
+```
+
+Filename `NNNN-kebab-title.md` (zero-padded sequential). Verb-led titles. **Immutable once accepted** — when a decision changes, write a new ADR with `Status: Superseded by ADR-NNNN` rather than editing in place.
+
 ## Arguments
 
 - `/plan` — ask for mode via AskUserQuestion
 - `/plan [mode]` — where mode is `interview`, `brainstorm`, `review`, or `visualize`
 - `/plan [mode] [spec-path]` — e.g. `/plan review auth-flow`
 - `--lifecycle` — force state × event matrix emission even when auto-detection signals don't fire
+- `--grill` — switch interview/brainstorm/review questioning into **grill mode**: one question at a time, always lead with the recommended answer, walk the decision tree branch-by-branch, update `CONTEXT.md` inline as terms resolve, propose ADRs only for hard-to-reverse decisions. See "Grill mode (modifier)" below.
 
 ## Lifecycle Detection (shared — runs before mode dispatch)
 
@@ -80,6 +144,27 @@ event_3          clear     clear     reject    clear
 Every cell is a review target — missing or fuzzy cells are the bugs. Derive states from the system's actual state enum (or the enum you are designing) and events from command entry points.
 
 ---
+
+## Grill mode (modifier)
+
+`--grill` is a **modifier**, not a separate mode. It applies on top of INTERVIEW, BRAINSTORM, or REVIEW. Detect it once, near the top:
+
+```bash
+echo "$ARGUMENTS" | grep -q -- '--grill' && GRILL=1
+```
+
+**When `GRILL=1`, the questioning style changes:**
+
+1. **One question at a time.** No multi-dimension batching. No "let me ask 5 things in this round." Walk the decision tree branch-by-branch — resolve dependencies between decisions one-by-one. Wait for the user's answer before continuing.
+2. **Always lead with your recommended answer.** Format every question as: *"My recommendation: X. Reason: Y. But before I commit, [the actual question]."* Never ask open-ended questions without a recommendation — the user pushes back on yours instead of generating from scratch.
+3. **Prefer codebase exploration over asking.** If a question can be answered by reading the code, read the code instead of asking. Only ask the user when the answer genuinely requires their judgment (product intent, tradeoff weighting, future plans).
+4. **Read `.out-of-scope/` early.** If the repo has `.out-of-scope/<slug>.md` rejection records, scan them before you start asking — don't re-litigate decisions that were already rejected for durable reasons. If a candidate seems to fall under an existing rejection, surface that to the user up front rather than walking the whole tree to the same dead end.
+5. **Challenge against `CONTEXT.md` inline.** When the user uses a term that conflicts with the glossary, call it out immediately: *"`CONTEXT.md` defines 'cancellation' as X, but you seem to mean Y — which is it?"* When a fuzzy term gets sharpened, **update `CONTEXT.md` right there** — don't batch glossary updates to the end.
+6. **Cross-reference with code.** When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: *"Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"*
+7. **Propose ADRs sparingly.** Only offer to write an ADR when **all three** are true: hard to reverse, surprising without context, result of a real trade-off. If any is missing, skip — for non-ADR-worthy rejections, suggest `/sweep-issues` write a `.out-of-scope/<slug>.md` record instead. Decisions that are easy to revisit don't need an ADR — they create noise.
+8. **Stop only when the user says stop or the tree is fully resolved.** Grill mode is "relentless" by design — it's how you flush out misalignment before code is written. Don't wrap up just because you've run several rounds; wrap up when the decision tree has no unresolved branches.
+
+When `GRILL=0` (default), the existing INTERVIEW / BRAINSTORM / REVIEW question styles apply as written below.
 
 ## Mode Selection
 

--- a/.claude/skills/prevent/SKILL.md
+++ b/.claude/skills/prevent/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: prevent
 version: 1.0.0
 description: |

--- a/.claude/skills/prevent/SKILL.md
+++ b/.claude/skills/prevent/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: prevent
 version: 1.0.0
 description: |

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: qa
 version: 1.0.0
 description: |

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: qa
 version: 1.0.0
 description: |

--- a/.claude/skills/qa/references/issue-taxonomy.md
+++ b/.claude/skills/qa/references/issue-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 ---
 
 # QA Issue Taxonomy

--- a/.claude/skills/qa/references/issue-taxonomy.md
+++ b/.claude/skills/qa/references/issue-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 ---
 
 # QA Issue Taxonomy

--- a/.claude/skills/qa/templates/qa-report-template.md
+++ b/.claude/skills/qa/templates/qa-report-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 ---
 
 # QA Report: {APP_NAME}

--- a/.claude/skills/qa/templates/qa-report-template.md
+++ b/.claude/skills/qa/templates/qa-report-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 ---
 
 # QA Report: {APP_NAME}

--- a/.claude/skills/receiving-pr-feedback/SKILL.md
+++ b/.claude/skills/receiving-pr-feedback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: receiving-pr-feedback
 version: 1.0.0
 description: |

--- a/.claude/skills/receiving-pr-feedback/SKILL.md
+++ b/.claude/skills/receiving-pr-feedback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: receiving-pr-feedback
 version: 1.0.0
 description: |

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: retro
 version: 1.1.0
 description: |

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: retro
 version: 1.1.0
 description: |

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@03bb002
 name: review
 version: 1.1.0
 description: |
@@ -24,6 +24,12 @@ allowed-tools:
 # Pre-Landing PR Review
 
 You are running the `/review` workflow. Analyze the current branch's diff against main for structural issues that tests don't catch.
+
+## Domain awareness
+
+If the repo has a `CONTEXT.md` (or a `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files), read it before dispatching review agents. **Use its vocabulary verbatim** in findings — refer to the "Order intake module" if the glossary names it that, not "the order service." Inconsistent vocabulary in review feedback creates churn during execute/ship.
+
+If `docs/adr/` exists and the diff touches an area covered by an ADR, include "respect ADR-NNNN" in the relevant agent prompts so findings don't propose changes the ADR already rejected.
 
 ## Arguments
 

--- a/.claude/skills/review/checklist.md
+++ b/.claude/skills/review/checklist.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 ---
 
 # Pre-Landing Review Checklist

--- a/.claude/skills/review/checklist.md
+++ b/.claude/skills/review/checklist.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 ---
 
 # Pre-Landing Review Checklist

--- a/.claude/skills/review/greptile-triage.md
+++ b/.claude/skills/review/greptile-triage.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 ---
 
 # Greptile Comment Triage

--- a/.claude/skills/review/greptile-triage.md
+++ b/.claude/skills/review/greptile-triage.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 ---
 
 # Greptile Comment Triage

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: session-start
 description: Load full project context — reads all .md files, specs, changelog, and git history to produce a prioritized project briefing
 user-invocable: true

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: session-start
 description: Load full project context — reads all .md files, specs, changelog, and git history to produce a prioritized project briefing
 user-invocable: true

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: ship
 version: 1.0.0
 description: |

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: ship
 version: 1.0.0
 description: |

--- a/.claude/skills/ship/pr-template.md
+++ b/.claude/skills/ship/pr-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 ---
 
 # PR Body Template

--- a/.claude/skills/ship/pr-template.md
+++ b/.claude/skills/ship/pr-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 ---
 
 # PR Body Template

--- a/.claude/skills/strategic-compact/SKILL.md
+++ b/.claude/skills/strategic-compact/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: strategic-compact
 description: Hook-driven strategic compaction system. Tracks tool call count and suggests /compact at logical intervals (50 calls, then every 25) to preserve context through phase transitions.
 user-invocable: false

--- a/.claude/skills/strategic-compact/SKILL.md
+++ b/.claude/skills/strategic-compact/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: strategic-compact
 description: Hook-driven strategic compaction system. Tracks tool call count and suggests /compact at logical intervals (50 calls, then every 25) to preserve context through phase transitions.
 user-invocable: false

--- a/.claude/skills/sweep-issues/SKILL.md
+++ b/.claude/skills/sweep-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@03bb002
 name: sweep-issues
 version: 1.0.0
 description: |
@@ -52,15 +52,27 @@ Review the conversation history and identify candidate items. For each, note:
 - **Why**: context from the conversation
 - **Source**: what triggered it (review finding, user comment, edge case discovered, etc.)
 - **Category**: `enhancement` | `bug` | `tech-debt` | `infrastructure`
+- **Mode**: `AFK` | `HITL`
+  - **AFK** — clearly-specified implementation, no design decisions or external access required. An agent could pick this up and run end-to-end through `/execute` autonomously.
+  - **HITL** — needs human-in-the-loop: a design decision the user must own, manual verification, external access, or domain knowledge an agent can't get from the code. Prefer AFK whenever possible — only mark HITL when there's a real reason an agent can't finish unattended.
 
-### Step 2: Deduplicate Against Existing Issues
+### Step 2: Deduplicate Against Existing Issues and Prior Rejections
 
-For each candidate, search existing issues:
+For each candidate:
+
+**2a. Search existing GitHub issues:**
 ```bash
 gh issue list --search "<keywords>" --limit 5
 ```
-
 Skip anything that's already tracked. If an existing issue is related but doesn't cover the new scope, note it as a cross-reference.
+
+**2b. Check `.out-of-scope/` for prior rejections.** If `.out-of-scope/` exists at the repo root, grep it for keyword matches against the candidate:
+```bash
+[ -d .out-of-scope ] && grep -rli "<keyword>" .out-of-scope/ 2>/dev/null
+```
+If a prior rejection covers the same idea, **skip the candidate silently** and note it in the report as `Skipped (out-of-scope: <slug>.md)`. Don't re-litigate decisions that were already made — that's the whole point of the knowledge base.
+
+If a prior rejection is *related but not the same scope*, surface it to the user: *"This is similar to a previous rejection (`.out-of-scope/<slug>.md`) but the new scope differs because X — proceed?"* The user decides whether the new scope warrants a new issue or whether to update the rejection record.
 
 ### Step 3: Present Candidates
 
@@ -102,6 +114,19 @@ EOF
 - `tech-debt` → `tech-debt`
 - `infrastructure` → `infrastructure`
 
+**Mode label** (additional, applied alongside category):
+- `AFK` → `afk` label
+- `HITL` → `hitl` label
+
+If the labels don't already exist on the repo, create them once. **Gate the create call** — `gh label create` errors on existing labels without `--force`, and `--force` would overwrite color/description on every run. Use:
+
+```bash
+gh label list --json name -q '.[].name' | grep -qx afk \
+  || gh label create afk --color 0E8A16 --description "Agent can complete unattended"
+gh label list --json name -q '.[].name' | grep -qx hitl \
+  || gh label create hitl --color FBCA04 --description "Needs human in the loop"
+``` The labels let `/execute --multi issue:...` filter for AFK-only work safe to fan out across panes, and let `/babysit-pr` flag HITL items that need user attention.
+
 ### Step 5: Report
 
 Output a summary:
@@ -114,11 +139,37 @@ Created N issues:
 Skipped M items (already tracked or too small).
 ```
 
+## Recording rejections to `.out-of-scope/`
+
+When the user says *"don't create that"*, *"we considered this and rejected it"*, or closes an enhancement as `wontfix`, **write a rejection record** to `.out-of-scope/<kebab-slug>.md`. Future `/sweep-issues` runs (and `/plan --grill`, `/improve-architecture`) read this directory to avoid re-suggesting the same thing.
+
+Format:
+
+```markdown
+---
+slug: <kebab-slug>
+rejected: YYYY-MM-DD
+related-issues: [#NN, #MM]   # optional — issues that triggered the rejection
+---
+
+# <Short title>
+
+**The proposal:** {1-2 sentences describing what was suggested.}
+
+**Why we rejected it:** {The load-bearing reason. This is the most important field — it must be specific enough that a future explorer reading this 6 months later understands why and doesn't re-suggest.}
+
+**What would change our minds:** {A concrete trigger that should reopen this. Examples: "if we ever add multi-tenancy", "if a customer asks for it more than 3 times", "if we hit N% error rate on the alternative". If nothing would change our minds, write "nothing — this is a permanent no" and explain why.}
+```
+
+Skip ephemeral reasons ("not worth it right now") — those become stale fast. Only record rejections with **durable** reasons, the kind that would still apply in 6 months.
+
 ## Important Rules
 
-- **Never create duplicate issues.** Always search first.
+- **Never create duplicate issues.** Always search GitHub *and* `.out-of-scope/` first.
 - **Never include secrets, credentials, API keys, or tokens in issue bodies.** Redact any sensitive data from conversation context before creating issues.
 - **Keep issues small and focused.** One issue per concern. Don't bundle unrelated items.
 - **Include enough context** that someone reading the issue 3 months from now understands what and why.
 - **Don't over-specify requirements.** 3-5 checklist items is ideal. The implementer will spec the details.
 - **Link related issues** when they exist (use `Related: #NNN` in the body).
+- **Tag mode (AFK / HITL).** Every created issue must carry exactly one of the `afk` or `hitl` labels.
+- **Record rejections, don't lose them.** When the user vetoes a candidate or closes an enhancement as `wontfix`, write `.out-of-scope/<slug>.md` so the rejection survives across sessions.

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: worktrees
 version: 1.0.0
 description: |

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@abe30a6
+_origin: calsuite@ca49d29
 name: worktrees
 version: 1.0.0
 description: |

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -1,0 +1,69 @@
+---
+_origin: calsuite@ca49d29
+name: zoom-out
+version: 1.0.0
+description: |
+  zoom out, give me a map, broader context, higher-level perspective, what's the big picture,
+  how does this fit, walk me through this area, I don't know this code, unfamiliar code,
+  give me the lay of the land, sketch the architecture here.
+  Single-purpose: agent goes up a layer of abstraction and produces a callers-and-collaborators
+  map for an unfamiliar area of code, using the project's domain vocabulary if CONTEXT.md exists.
+user-invocable: true
+argument-hint: "[path-or-symbol]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Agent
+---
+
+# /zoom-out
+
+You are unfamiliar with this area of code. Go **up** one layer of abstraction and produce a map.
+
+## Process
+
+1. **Resolve the target.** If `$ARGUMENTS` is a path, start there. If it's a symbol, grep for the definition. If empty, infer from the recent conversation (last file read, last function discussed) and confirm with the user before proceeding.
+
+2. **Read CONTEXT.md if it exists.** Check the repo root and any closer `CONTEXT.md` (multi-context repos use a `CONTEXT-MAP.md` at root pointing to per-module files). If found, **use its vocabulary exactly** — don't drift to synonyms. If absent, just describe the code in its own terms.
+
+3. **Build the map.** Use Grep / Glob to enumerate:
+   - **Callers** — who imports / invokes this module?
+   - **Collaborators** — what does it import / depend on?
+   - **Siblings** — peer modules in the same directory or layer.
+   - **Entry points** — what user-facing surface (route, CLI command, hook event, job) ultimately reaches it?
+
+   For larger areas, dispatch an `Explore` agent rather than walking the tree yourself.
+
+4. **Output.** A short hierarchical map plus 3-5 sentences of orientation. Format:
+
+   ```
+   <Target> sits inside <broader concept from CONTEXT.md or filesystem>.
+
+   Reached from:
+     - <entry point> → <intermediate> → <target>
+     - <entry point> → <target>
+
+   Calls into:
+     - <collaborator> — <what for>
+     - <collaborator> — <what for>
+
+   Peers (sibling modules):
+     - <peer> — <one-line role>
+     - <peer> — <one-line role>
+
+   Tests:
+     - <test file> — covers <surface>
+
+   Notes
+     - <one or two non-obvious facts: invariant, recent refactor, ADR reference>
+   ```
+
+5. **Stop.** Don't propose changes, don't fix things, don't grill. The goal is orientation only — the user takes it from there.
+
+## Gotchas
+
+- **Don't dump file contents** — the user already knows how to read. The job is shape and relationships, not source code.
+- **Don't speculate about what code "should" do.** Map what's there. If something is confusing, list it under Notes as a question, not a recommendation.
+- **Use CONTEXT.md vocabulary verbatim.** If the glossary calls it an "Order intake module," don't rewrite as "the order service." Drift defeats the point of having a glossary.
+- **Stay one layer up, not three.** Zooming too far loses signal. If the target is a function, map its module. If the target is a module, map its package. One step.

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@ca49d29
+_origin: calsuite@eb4661a
 name: zoom-out
 version: 1.0.0
 description: |
@@ -21,6 +21,16 @@ allowed-tools:
 
 You are unfamiliar with this area of code. Go **up** one layer of abstraction and produce a map.
 
+## Arguments
+
+- `/zoom-out` — no argument; infer the target from the recent conversation (last file read, last function discussed) and confirm with the user before mapping.
+- `/zoom-out <path-or-symbol>` — explicit target. The argument is matched against `argument-hint: "[path-or-symbol]"` in the frontmatter:
+  - **Path** (e.g. `src/billing/charges.ts`) — start there; map its module / package as the broader scope.
+  - **Symbol** (e.g. `applyDiscount`) — grep for the definition first, then proceed.
+  - Empty or ambiguous — fall through to the inference path above.
+
+The argument resolves at **Step 1: Resolve the target** in the Process below. Tools available are read-only (`Read`, `Grep`, `Glob`, `Agent` per the frontmatter) — the skill cannot modify files.
+
 ## Process
 
 1. **Resolve the target.** If `$ARGUMENTS` is a path, start there. If it's a symbol, grep for the definition. If empty, infer from the recent conversation (last file read, last function discussed) and confirm with the user before proceeding.
@@ -37,7 +47,7 @@ You are unfamiliar with this area of code. Go **up** one layer of abstraction an
 
 4. **Output.** A short hierarchical map plus 3-5 sentences of orientation. Format:
 
-   ```
+   ```text
    <Target> sits inside <broader concept from CONTEXT.md or filesystem>.
 
    Reached from:


### PR DESCRIPTION
## Summary

Sync of [ckallum/calsuite#72](https://github.com/ckallum/calsuite/pull/72) (calsuite v2.23) into this repo's `.claude/` distribution.

### Substantive content changes

| File | What changed |
|---|---|
| `.claude/skills/improve-architecture/SKILL.md` + `LANGUAGE.md` | **New skill** — periodic codebase-health review with deletion test and fixed architectural vocabulary |
| `.claude/skills/zoom-out/SKILL.md` | **New skill** — orientation micro-skill, one layer up |
| `.claude/skills/plan/SKILL.md` | `--grill` modifier (one-question decision-tree walk, lead with recommendation) + inline CONTEXT.md/ADR format guidance + Domain awareness section |
| `.claude/skills/debug/SKILL.md` | Phase 1 reframed as "Build a feedback loop" with 10-tactic ladder; the loop IS the skill |
| `.claude/skills/skill-builder/SKILL.md` | 10-item review checklist (Step 6) before confirmation |
| `.claude/skills/sweep-issues/SKILL.md` | AFK/HITL labels with idempotent label-create + `.out-of-scope/<slug>.md` rejection knowledge base |
| `.claude/skills/guardian/SKILL.md` | AFK/HITL aliases for autonomous/supervised + cross-skill composition table |
| `.claude/skills/execute/SKILL.md` | AFK/HITL runtime routing + CONTEXT.md/ADR awareness |
| `.claude/skills/review/SKILL.md` | Domain awareness — uses CONTEXT.md vocabulary verbatim in findings |
| `.claude/skills/learn/SKILL.md` | Learning vs CONTEXT.md term vs ADR triage table |

### Mechanical changes

The remaining ~20 modified files (`babysit-pr`, `context7`, `customise`, `lint-rule-gen`, `new-spec`, `plan-ceo`, `prevent`, `qa`, `receiving-pr-feedback`, `retro`, `session-start`, `ship`, `worktrees`, `agents/code-reviewer.md`, etc.) are `_origin` SHA bumps from the post-commit sync — every pristine file gets re-stamped with the new calsuite SHA. No content changes.

## Pre-Landing Review

Substantive content was reviewed in [calsuite#72](https://github.com/ckallum/calsuite/pull/72) before merge — 6 critical findings resolved inline plus 5 informational tightenings. No new review needed for the sync itself.

## Test Results

No tests run — markdown/skill-distribution changes only; no functional code touched.

## Doc Completeness

- [x] No CLAUDE.md in this repo references skills directly — no doc updates needed
- [x] Sync is mechanical via post-commit hook from calsuite

🤖 Generated with [Claude Code](https://claude.com/claude-code)