### PR TITLE
chore: refresh calsuite _origin markers

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: code-reviewer
 description: "Reviews staged git changes against CLAUDE.md conventions and codebase patterns. Returns PASS/BLOCKED verdict. Spawn with: @code-reviewer"
 model: sonnet

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: babysit-pr
 version: 1.0.0
 description: |

--- a/.claude/skills/context7/SKILL.md
+++ b/.claude/skills/context7/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: context7
 description: "Look up current, version-specific library documentation using Context7. Use proactively when working with libraries or explicitly via /context7."
 user-invocable: true

--- a/.claude/skills/customise/SKILL.md
+++ b/.claude/skills/customise/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: customise
 description: |
   customise a skill for this project, fork a skill locally, project-specific skill tweak,

--- a/.claude/skills/improve-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-architecture/LANGUAGE.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 ---
 
 # Architectural Language

--- a/.claude/skills/improve-architecture/SKILL.md
+++ b/.claude/skills/improve-architecture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: improve-architecture
 version: 1.0.0
 description: |

--- a/.claude/skills/lint-rule-gen/SKILL.md
+++ b/.claude/skills/lint-rule-gen/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: lint-rule-gen
 version: 1.0.0
 description: |

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: new-spec
 description: |
   Scaffold a new spec directory with requirements.md, design.md, and tasks.md

--- a/.claude/skills/plan-ceo/SKILL.md
+++ b/.claude/skills/plan-ceo/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: plan-ceo
 version: 1.0.0
 description: |

--- a/.claude/skills/prevent/SKILL.md
+++ b/.claude/skills/prevent/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: prevent
 version: 1.0.0
 description: |

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: qa
 version: 1.0.0
 description: |

--- a/.claude/skills/qa/references/issue-taxonomy.md
+++ b/.claude/skills/qa/references/issue-taxonomy.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 ---
 
 # QA Issue Taxonomy

--- a/.claude/skills/qa/templates/qa-report-template.md
+++ b/.claude/skills/qa/templates/qa-report-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 ---
 
 # QA Report: {APP_NAME}

--- a/.claude/skills/receiving-pr-feedback/SKILL.md
+++ b/.claude/skills/receiving-pr-feedback/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: receiving-pr-feedback
 version: 1.0.0
 description: |

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: retro
 version: 1.1.0
 description: |

--- a/.claude/skills/review/checklist.md
+++ b/.claude/skills/review/checklist.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 ---
 
 # Pre-Landing Review Checklist

--- a/.claude/skills/review/greptile-triage.md
+++ b/.claude/skills/review/greptile-triage.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 ---
 
 # Greptile Comment Triage

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: session-start
 description: Load full project context — reads all .md files, specs, changelog, and git history to produce a prioritized project briefing
 user-invocable: true

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: ship
 version: 1.0.0
 description: |

--- a/.claude/skills/ship/pr-template.md
+++ b/.claude/skills/ship/pr-template.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 ---
 
 # PR Body Template

--- a/.claude/skills/strategic-compact/SKILL.md
+++ b/.claude/skills/strategic-compact/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: strategic-compact
 description: Hook-driven strategic compaction system. Tracks tool call count and suggests /compact at logical intervals (50 calls, then every 25) to preserve context through phase transitions.
 user-invocable: false

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: worktrees
 version: 1.0.0
 description: |

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@eb4661a
+_origin: calsuite@73b2e03
 name: zoom-out
 version: 1.0.0
 description: |


### PR DESCRIPTION
## Summary

Refreshes the `_origin: calsuite@<sha>` frontmatter marker on 23 calsuite-distributed `.claude/` files. Bumps from `calsuite@eb4661a` → `calsuite@73b2e03` (the merge commit of [calsuite#75](https://github.com/ckallum/calsuite/pull/75)).

**No content changes.** Each file's body is byte-identical to the previously committed version; only the frontmatter SHA marker is updated.

## Why

calsuite's installer (`configure-claude.js --sync`) rewrites the `_origin` marker on every sync to track which calsuite revision distributed each file. After PR #75 landed in calsuite main, the next sync stamped 73b2e03 across all distributed files, even though most content was unchanged. This PR commits that stamp refresh so the working tree returns to clean.

## Files

23 files, all 1-line `_origin` edits. Full list in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)