### PR TITLE
chore: add /flow and /spec-interview skills, refresh /layman and /ship

### DIFF
--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -1,0 +1,83 @@
+---
+_origin: calsuite@e7c9e27
+name: flow
+version: 1.0.0
+description: |
+  Generate a Mermaid flowchart diagram of the current session's development
+  workflow — which skills and agents ran, in what order, with parallel edges
+  and collapsed repeated dispatches.
+allowed-tools:
+  - Read
+  - Bash
+---
+
+# Flow: Session Workflow Diagram
+
+You are running the `/flow` skill. Generate a Mermaid diagram showing the development workflow trace for the current session.
+
+## Steps
+
+### 1. Find the trace file
+
+The trace file is at `.claude/flow-trace-{CLAUDE_SESSION_ID}.jsonl` in the project root. The `CLAUDE_SESSION_ID` environment variable identifies the current session.
+
+```bash
+cat "${CLAUDE_PROJECT_DIR:-.}/.claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
+```
+
+If the file is missing or empty, respond with:
+> No trace data found for this session.
+
+Then **STOP**. Do not output an empty diagram.
+
+### 2. Parse JSONL entries
+
+Each line is a JSON object with:
+- `ts` — ISO timestamp (used for ordering and parallel detection)
+- `type` — `"skill"` or `"agent"`
+- `name` — skill name or agent subagent_type
+- `description` — (agents only) task description
+- `args` — (skills only) arguments passed
+
+Sort entries by `ts` to determine ordering.
+
+### 3. Build the Mermaid flowchart
+
+Generate a `flowchart TD` with these rules:
+
+**Node shapes:**
+- Skill nodes: rounded rectangle — `S1(skill-name)`
+  - If `args` is non-null, include it: `S1(skill-name: args)`
+- Agent nodes: hexagon — `A1{{agent-type: description}}`
+  - Truncate description to ~40 chars if longer
+
+**Edges:**
+- Sequential entries get `-->` edges connecting them in order
+- **Parallel detection:** If two or more entries share the same predecessor AND their timestamps are within 1 second of each other, draw them as parallel edges from the predecessor (fan-out)
+- **Collapse repeats:** If N consecutive entries have the same `type` AND `name`, collapse into a single node with a multiplier label, e.g. `A3{{general-purpose: Run tests x3}}`
+
+**Node ID convention:**
+- Skills: `S1`, `S2`, `S3`, ...
+- Agents: `A1`, `A2`, `A3`, ...
+- Number each type independently
+
+### 4. Output
+
+Output a fenced Mermaid code block:
+
+````markdown
+```mermaid
+flowchart TD
+    S1(plan) --> A1{{Explore: Find auth middleware}}
+    S1 --> A2{{Explore: Find hooks config}}
+    A1 --> S2(execute)
+    A2 --> S2
+    S2 --> A3{{code-reviewer: Review changes}}
+    S2 --> A4{{general-purpose: Run tests x3}}
+    A3 --> S3(ship)
+    A4 --> S3
+    S3 --> S4(flow)
+```
+````
+
+Keep the diagram clean and readable. If there are more than 20 nodes, summarize middle sections (e.g., collapse sequential agent dispatches more aggressively).

--- a/.claude/skills/layman/SKILL.md
+++ b/.claude/skills/layman/SKILL.md
@@ -1,4 +1,5 @@
 ---
+_origin: calsuite@e7c9e27
 name: layman
 description: Summarise a code change in plain, non-technical language with real-life analogies and a clear flow
 user-invocable: true

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@73b2e03
+_origin: calsuite@a60b539
 name: ship
 version: 1.0.0
 description: |
@@ -59,6 +59,22 @@ EOF
 ```
 
 Use `docs:` for documentation, `chore:` for config/skills, `style:` for formatting. If there are already commits on the branch and no uncommitted changes, skip this step.
+
+### Step 2.5: Sweep and fix PR-introduced bugs inline
+
+Even in pr-only mode, scan the conversation for **bugs in code this branch is changing**. PR-only mode skips tests, review, and simplification — but it must NOT skip the rule that bugs introduced by the PR get fixed in the PR.
+
+```bash
+git diff origin/main --name-only > /tmp/ship-changed-files.txt
+```
+
+Hold the contents as `CHANGED_FILES`. Review the conversation for any minor bugs, TODOs, edge cases, or rough edges that surfaced during the work. For each candidate, check whether it touches `CHANGED_FILES`:
+
+- **If yes and it's a bug:** fix it now, stage, commit (`git commit -m "fix: <what>"`). No exceptions.
+- **If yes and it's an enhancement/cleanup:** default to fixing inline unless it would meaningfully grow the PR.
+- **If no:** defer to Step 4 (the post-PR `/sweep-issues` call will create the issue).
+
+Skip this step silently if no candidates surfaced.
 
 ### Step 3: Push, run Pre-PR Gates, create PR
 
@@ -258,23 +274,34 @@ git push -u origin $(git branch --show-current)
 
 **Before** running Pre-PR Gates, scan the conversation for deferred items, fast-follows, minor bugs, enhancements, and tech debt — the same categories `/sweep-issues` looks for. Fix anything coherent with the current PR; defer the rest to Step 9.
 
-### 7.2a: Gather candidates
+### 7.2a: Gather candidates and capture the diff file list
 
-Review the conversation for deferred work, TODOs, edge cases, minor bugs, and improvements. For each item, note a one-line description and its source (conversation turn, review finding, etc.).
+First, capture the canonical list of files this branch touches — every later triage decision is grounded against it:
+
+```bash
+git diff origin/main --name-only > /tmp/ship-changed-files.txt
+```
+
+Hold the contents as `CHANGED_FILES`. Then review the conversation for deferred work, TODOs, edge cases, minor bugs, and improvements. For each item, note a one-line description, its source (conversation turn, review finding, etc.), and **the file(s) it relates to** if known.
 
 ### 7.2b: Triage — fix now vs. create issue
+
+For each candidate, first check whether it touches `CHANGED_FILES`. **If it does, default to "fix now"** — the reviewer is going to see those files anyway, and any bug, TODO, or rough edge in them belongs in the same PR. Only override the default if the user explicitly confirms the issue is pre-existing and out of scope.
 
 Classify each candidate:
 
 | Fix now (inline) | Create issue (later) |
 |---|---|
-| Minor bug in code touched by this PR | Feature request unrelated to this PR |
-| Missing edge case in a function this PR added/modified | Large refactor spanning multiple files not in this diff |
-| TODO/FIXME left in files changed by this PR | Work that requires design discussion |
-| Small enhancement coherent with the PR's purpose | Performance optimization with unclear scope |
-| Cleanup in files already being modified | Anything that would change the PR's scope significantly |
+| **Anything touching a file in `CHANGED_FILES`** (default) | Feature request unrelated to this PR |
+| Minor bug in code touched by this PR | Large refactor spanning multiple files not in this diff |
+| Missing edge case in a function this PR added/modified | Work that requires design discussion |
+| TODO/FIXME left in files changed by this PR | Performance optimization with unclear scope |
+| Small enhancement coherent with the PR's purpose | Anything that would change the PR's scope significantly |
+| Cleanup in files already being modified | Pre-existing bug in a file this PR doesn't touch |
 
-**The test:** "Would a reviewer expect this to be part of this PR?" If yes → fix now. If no → create issue.
+**The test:** "Would a reviewer expect this to be part of this PR?" If the candidate's file is in `CHANGED_FILES`, the answer is almost always yes — fix now. If no → create issue.
+
+**Bugs introduced by this PR are never deferrable.** If a candidate is a bug AND its file is in `CHANGED_FILES`, fix it inline. Do not move it to the "create issue" column even if the user requested deferring something else.
 
 ### 7.2c: Apply inline fixes
 
@@ -538,7 +565,7 @@ args: ""
 - **Simplify runs BEFORE review** so the review stamp covers the final code state. Don't reorder Steps 4 and 4.5.
 - **`git push` may fail if the branch was force-pushed elsewhere.** Never force push to recover — ask the user.
 - **CHANGELOG auto-generation reads all commits on the branch** — if prior commits have bad messages, the CHANGELOG entries will be vague.
-- **`/ship pr` skips ALL safety checks** (tests, review, simplification). Only use for genuinely low-risk changes. If in doubt, use `/ship`.
+- **`/ship pr` skips the heavy safety checks** (full test suite, simplification, Pre-Landing Review, CHANGELOG generation, commit splitting) but still runs the cheap ones: the Step 2.5 PR-introduced-bug sweep, the Pre-PR Gates from Step 7.4 (PR-size, test-presence, spec-contract), and the PR-claim-vs-diff grep (Step 8.5). Use for genuinely low-risk changes (docs, config, skills); if in doubt, use `/ship`.
 - **Pre-PR Gates (Step 7.4) warn but do not block** unless `.claude/ship-config.json` sets `strict: true`. They surface context about the diff shape — large PRs, no-test diffs, spec deviations — but the user always has the final word.
 - **`.claude/ship-config.json` is optional and per-repo.** Keys: `criticalPaths: [glob, ...]` for strict test-presence on sensitive files, `strict: true` to promote the strict warning into a block. Only the test-presence gate reads this file — size, spec-contract, and claim-grep gates run unconditionally.
 - **PR-claim-vs-diff grep (Step 8.5) uses literal string search.** A claim is missing if `grep -F` doesn't find it in the full diff. If the code renamed a symbol that the PR body still references, the grep correctly flags it.

--- a/.claude/skills/spec-interview/SKILL.md
+++ b/.claude/skills/spec-interview/SKILL.md
@@ -1,0 +1,37 @@
+---
+_origin: calsuite@e7c9e27
+name: spec-interview
+description: Conduct an in-depth interview about a spec document to surface edge cases, tradeoffs, and non-obvious decisions, then write the final spec. Use when a SPEC.md exists and needs to be fleshed out.
+disable-model-invocation: true
+argument-hint: [spec-file-path]
+---
+
+Conduct an in-depth interview about a spec document, then write the final spec.
+
+## Instructions
+
+When this skill is invoked:
+
+1. **Find the spec file.** If `$ARGUMENTS` is provided, use that as the file path. Otherwise, look for files matching `**/SPEC.md`, `**/spec.md`, or similar in the current project. If multiple are found or none exist, use AskUserQuestion to ask which file to use or where to create one. Read the file contents thoroughly.
+
+2. **Interview the user.** Conduct a deep, multi-round interview using AskUserQuestion. The goal is to surface non-obvious decisions, edge cases, and tradeoffs that the spec doesn't address or is ambiguous about.
+
+   Interview guidelines:
+   - **Do NOT ask obvious questions** that the spec already answers clearly. Read the spec carefully first.
+   - **Do ask about:** hidden complexity, conflicting requirements, unstated assumptions, failure modes, edge cases, scaling concerns, security implications, data model subtleties, UX micro-interactions, state management tradeoffs, migration paths, backwards compatibility, error handling strategy, performance budgets, accessibility considerations, and integration boundaries.
+   - **Be specific.** Reference concrete parts of the spec. Instead of "how should errors work?", ask "when the payment webhook fails mid-checkout and the user has already seen the success screen, what should happen?"
+   - **Go deep on answers.** Follow up on interesting responses. If the user says "we'll use a queue", ask about retry policy, dead letters, ordering guarantees, idempotency.
+   - **Cover multiple dimensions per round.** Use multi-question AskUserQuestion calls (up to 4 questions) to keep the interview moving efficiently.
+   - **Provide informed options.** When asking about tradeoffs, present concrete options with pros/cons rather than open-ended questions.
+
+3. **Continue until complete.** Keep interviewing across multiple rounds. A thorough interview typically needs 4-8 rounds depending on spec complexity. You are done when:
+   - All major architectural decisions are resolved
+   - Edge cases and error flows are addressed
+   - The user confirms they have nothing else to add
+
+4. **Write the final spec.** Once the interview is complete, rewrite the spec file incorporating all decisions from the interview. The final spec should:
+   - Preserve the original structure and intent
+   - Integrate all interview answers as concrete decisions (not as Q&A)
+   - Add new sections for topics that emerged during the interview
+   - Be written as a definitive spec, not a discussion document
+   - Flag any remaining open questions that weren't resolved


### PR DESCRIPTION
## Summary

- Add `/flow` skill — generates a Mermaid flowchart of the session's skill and agent dispatch trace; used downstream by `/ship` to embed a Development Flow section in PR bodies.
- Add `/spec-interview` skill — structured interview workflow against a `SPEC.md` to surface edge cases, tradeoffs, and non-obvious decisions, then write the final spec.
- Refresh `/layman` — add `_origin: calsuite@e7c9e27` marker, no functional change.
- Refresh `/ship` from `calsuite@73b2e03` → `calsuite@a60b539`:
  - Adds Step 2.5 in PR-only mode — sweep for PR-introduced bugs inline so PR-only mode does not skip the "bugs in the diff get fixed in the diff" rule.
  - Tightens Step 7.2a/7.2b — captures a `CHANGED_FILES` list from the diff and defaults "anything touching a file in `CHANGED_FILES`" to fix-now triage.
  - Refines the `/ship pr` safety-check gotcha — the cheap gates (size, test-presence, spec-contract, claim-grep) still run.

All four skills are upstream calsuite syncs. No project-specific logic added.

## Important Files

| File | Description |
| --- | --- |
| `.claude/skills/flow/SKILL.md` | New 83-line skill — Mermaid flowchart generator from the session's `flow-trace-${session_id}.jsonl`. |
| `.claude/skills/spec-interview/SKILL.md` | New 37-line skill — multi-round AskUserQuestion interview against a spec file, then writes the final spec. |
| `.claude/skills/ship/SKILL.md` | +37/-10 — Step 2.5 added, Step 7.2a/7.2b tightened, gotcha refined. |
| `.claude/skills/layman/SKILL.md` | +1 — `_origin` marker. |

## Doc Completeness

- [x] Each new skill has frontmatter with `name`, `description`, and (for user-invocable skills) the trigger surface.
- [x] No README/CLAUDE.md update required — the skills register themselves via the standard `.claude/skills/` discovery path.
- [x] No CHANGELOG entry — repo does not maintain one (vault project).

## Out of scope

The `.claude/specs/entity-screen-bait/` directory that previously sat in this working tree has been moved to `.raw/specs/entity-screen-bait/` (gitignored) before this commit, so it does not appear in the diff. The [entity-screen-bait-spec](wiki/sources/entity-screen-bait-spec.md) wiki page now references the new path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flow skill to generate visual workflow diagrams of development sessions.
  * Added spec-interview skill for automated requirements gathering and specification refinement.

* **Improvements**
  * Enhanced PR handling with improved bug detection, inline fixing, and triage logic for changed files.

* **Chores**
  * Updated skill metadata and documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ckallum/timeline/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->