### PR TITLE
chore(claude): sync calsuite skills (improve-prompt, /code-review rename, _origin bumps)

### DIFF
--- a/.claude/skills/execute/SKILL.md
+++ b/.claude/skills/execute/SKILL.md
@@ -257,7 +257,7 @@ description: "Quality review: <task title>"
 
 ### 3d: Simplify
 
-After quality review passes, run `/simplify` to clean up the changed code — reuse opportunities, clarity, consistency. This ensures the final code is polished before marking the task complete.
+After quality review passes, run `/code-review` to clean up the changed code — reuse opportunities, clarity, consistency. This ensures the final code is polished before marking the task complete.
 
 ### 3e: Mark task complete
 

--- a/.claude/skills/improve-architecture/SKILL.md
+++ b/.claude/skills/improve-architecture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@0e177a4
+_origin: calsuite@0ce554a
 name: improve-architecture
 version: 1.0.0
 description: |
@@ -26,7 +26,7 @@ allowed-tools:
 
 Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The goal is testability and AI-navigability: a codebase a fresh agent can navigate quickly, with bugs concentrated in one place, not scattered.
 
-Run periodically — every few weeks, or when the codebase starts to feel like a ball of mud. Pairs with `/simplify` (per-change cleanup) and `/review` (pre-merge) — `/improve-architecture` is the **codebase-wide health check** the others don't do.
+Run periodically — every few weeks, or when the codebase starts to feel like a ball of mud. Pairs with `/code-review` (per-change cleanup) and `/review` (pre-merge) — `/improve-architecture` is the **codebase-wide health check** the others don't do.
 
 ## Vocabulary
 
@@ -200,6 +200,6 @@ This gives the next audit (in a few weeks) a starting point and prevents re-liti
 - **Don't propose interfaces in Step 4.** Wait for the user to pick a candidate. Proposing concrete interfaces upfront is wasted work — most candidates won't be picked.
 - **Use the deletion test, not feel.** "This feels too shallow" is not a finding. "Deleting this module would push complexity into 5 callers, none of which would benefit from owning that complexity" is.
 - **Don't re-litigate ADRs unprompted.** If a candidate contradicts an ADR and the friction isn't severe, drop it silently. Only surface ADR-contradicting candidates when the friction is real and worth a discussion.
-- **Stay codebase-wide unless scoped.** This is the proactive health check — `/simplify` already covers per-change cleanup. If the user wants a focused review, they'll pass a path argument.
+- **Stay codebase-wide unless scoped.** This is the proactive health check — `/code-review` already covers per-change cleanup. If the user wants a focused review, they'll pass a path argument.
 - **The skill is read-and-decide, not write-and-implement.** When a candidate is approved, hand off to `/plan review` → `/execute`. Don't refactor inside this skill.
 - **AFK / HITL marking on follow-up issues.** When approved candidates spawn issues (via `/sweep-issues`), tag them AFK (clearly-spec'd refactor) or HITL (needs design decision) per the standard convention.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@4f73df3
+_origin: calsuite@0ce554a
 name: ship
 version: 1.0.0
 description: |
@@ -84,7 +84,7 @@ git push -u origin $(git branch --show-current)
 
 Run the Pre-PR Gates from **Step 7.4** (PR-size, test-presence, spec-contract) before drafting the body. Even in pr-only mode, these gates surface useful warnings — the test-presence gate typically stays silent on docs/config changes because it only warns when `code_additions > 50`. Spec-contract still applies if the repo has active specs.
 
-Read the PR body template at `skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
+Read the PR body template at `.claude/skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
 
 Run **Step 8.5** (PR-claim-vs-diff grep) against the drafted body before calling `gh pr create`.
 
@@ -342,7 +342,7 @@ fi
 ```
 
 If `added > 400`, emit:
-```
+```text
 ⚠ PR size: <N> lines added. Large PRs get surface-level reviews.
   Top files:
     <N1> lines  <path1>
@@ -376,7 +376,7 @@ code_additions=$(git diff origin/main -- \
 ```
 
 If `code_additions > 50` AND `new_tests == 0`, emit:
-```
+```text
 ⚠ Test-presence: <N> lines of code added, zero new tests.
   Code-only files (no tests alongside):
     <list of non-test files with net-positive additions>
@@ -403,7 +403,7 @@ fi
 
 For each critical glob, check whether any diff file matches it (use the same glob-matching logic as `lint-gate.cjs`). If a critical path is touched AND `new_tests == 0`, emit a strong warning that cites the matching glob:
 
-```
+```text
 ⚠ Test-presence (STRICT): critical path touched without tests.
   Matched glob: <glob pattern>
   Files: <matching files from diff>
@@ -433,7 +433,7 @@ Flag two classes:
   - **EXTRA:** diff introduces behavior (new command handler, new event emitter, new persisted field) not described anywhere in `design.md`.
 
 For each deviation, use AskUserQuestion individually:
-```
+```text
 <Deviation description — what the spec says vs what the diff does>
 
 Recommendation: [A or B, lead with your pick and 1-sentence reason]
@@ -484,7 +484,7 @@ If the trace file is missing or empty, skip the `## Development Flow` section en
 
 ## Step 8: Draft PR body
 
-Read the PR body template at `skills/ship/pr-template.md` and follow its structure exactly.
+Read the PR body template at `.claude/skills/ship/pr-template.md` and follow its structure exactly.
 
 Populate each section:
 - **Summary** — bullet points from CHANGELOG entries (what shipped)
@@ -519,7 +519,7 @@ Before creating the PR, cross-check the drafted body against the actual diff. Th
    ```
 
 3. If any claims are missing from the diff, surface them above the PR body draft:
-   ```
+   ```text
    ⚠ PR body claims not found in diff:
      - `hydrated_from_storage`  — mentioned in Summary, not in any changed file
      - `session-hydrate-degraded` — mentioned in How It Works, not emitted anywhere


### PR DESCRIPTION
## Summary

Sync calsuite skill updates accumulated since the last sync. Three threads bundled into one PR:

- **`skills/improve-prompt/`** — new skill from calsuite v2.31. Audits and rewrites prompts against [Anthropic's prompt-engineering best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices).
- **`_origin` sha bumps on `improve-architecture` and `ship`** — pristine files re-stamped at current calsuite sha.
- **`/simplify` → `/code-review` rename** — Claude Code 2.1.146 renamed the built-in `/simplify` skill. Updated `skills/execute/SKILL.md` Step 3d and `skills/improve-architecture/SKILL.md` pair-skill mentions (×2). Latest calsuite sha: `0ce554a` (v2.32).
- **`skills/ship`** — refresh to current calsuite content.
- Plus one local fix: keep checklist scope content-only on multi-step reasoning item.

## Source
- [calsuite#89](https://github.com/ckallum/calsuite/pull/89) — `/simplify` → `/code-review` rename
- calsuite#87 — `/improve-prompt` skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)