### PR TITLE
chore(claude): sync calsuite skills to dfaf5b4

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@03bb002
+_origin: calsuite@dfaf5b4
 name: debug
 version: 1.0.0
 description: |

--- a/.claude/skills/execute/SKILL.md
+++ b/.claude/skills/execute/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@03bb002
+_origin: calsuite@dfaf5b4
 name: execute
 version: 2.1.0
 description: |
@@ -28,7 +28,34 @@ Flexible execution skill with three modes plus a parallel multi-pane launcher. A
 
 ## AFK vs HITL handling (shared)
 
-If the source task is labeled **AFK** (e.g. issue carries the `afk` label, or the spec/conversation marks it AFK), proceed end-to-end through the execution loop without pausing for confirmation between phases — that's what AFK means. If labeled **HITL**, the implementer pauses at each decision point and asks via AskUserQuestion before proceeding. Default when unlabeled: behave as HITL — only escalate to AFK behavior when explicitly marked or when the user is running under `/guardian mode autonomous`.
+See `/guardian`'s "How AFK/HITL composes across skills" section for the authoritative definitions and how the label cascades from `/sweep-issues` (classification) through here (execution) to `/guardian` (permissions). At this layer:
+
+- **AFK-labelled task** (issue carries `afk`, or spec/conversation marks it AFK): proceed end-to-end through the execution loop without pausing for confirmation between phases.
+- **HITL-labelled task**: pause at each decision point and ask via AskUserQuestion before proceeding.
+- **Unlabelled**: behave as HITL — only escalate to AFK when explicitly marked or when the user is running under `/guardian mode autonomous`.
+
+### Resolving the mode (compute once, use everywhere)
+
+Compute a single `MODE` value at the start of execution and reuse it at every AskUserQuestion call site below:
+
+```bash
+# Pseudocode — adapt to the actual decision flow
+MODE=hitl                                          # default
+issue_has_label_afk && MODE=afk                    # ISSUE mode: read labels
+spec_or_user_marks_afk && MODE=afk                 # SPEC / RAW mode: explicit marker
+guardian_mode_is_autonomous && MODE=afk            # session-wide override
+```
+
+### AskUserQuestion gating rule
+
+Every AskUserQuestion call below falls into one of two categories:
+
+| Category | AFK behavior | HITL behavior |
+|---|---|---|
+| **Phase confirmation** — "proceed?", "continue?", "raise concerns?" between phases | **Skip** the prompt; proceed automatically and log the auto-decision in the batch report | Ask normally |
+| **User-owned decision** — actions that change shared state outside this run (close issue, post comment, push to remote, send notification) | **Always ask** regardless of mode — AFK does not authorize state changes the user hasn't explicitly delegated | Ask normally |
+
+Each AskUserQuestion call site below explicitly states which category it belongs to. The default for ambiguous calls is **phase confirmation** (skippable in AFK) — be conservative about marking a call user-owned, but never auto-execute issue-close, force-push, or external-system writes without explicit user confirmation.
 
 ## Domain awareness (shared, runs before any mode)
 
@@ -114,7 +141,7 @@ Otherwise, parse `$ARGUMENTS`:
 1. Summarize what the user wants from conversation context into a concrete task list.
 2. Explore the codebase to understand relevant files, patterns, and conventions.
 3. Break the work into discrete, ordered tasks (same format as `tasks.md`).
-4. Present via AskUserQuestion:
+4. **Phase confirmation** — present via AskUserQuestion **only if `MODE=hitl`**; in AFK mode, accept the derived task list and the 2-3 sentence intent summary as `COMPLIANCE_REFERENCE` automatically and log the auto-decision in the eventual batch report:
 
 > Here's what I understand you want to implement:
 > - Task 1: [description]
@@ -126,7 +153,7 @@ Otherwise, parse `$ARGUMENTS`:
 >
 > A) Proceed  B) Let me clarify
 
-Store the confirmed summary as `COMPLIANCE_REFERENCE`.
+Store the confirmed (or auto-accepted) summary as `COMPLIANCE_REFERENCE`.
 
 ### SPEC Mode
 
@@ -151,7 +178,7 @@ gh issue view <number> --json title,body,labels,comments,assignees
    - If it contains checklists (`- [ ]` items), extract them as tasks directly.
    - If prose only, derive discrete tasks (same approach as RAW mode).
 
-3. Present via AskUserQuestion:
+3. **Phase confirmation** — present via AskUserQuestion **only if `MODE=hitl`**; in AFK mode, accept the derived task list automatically:
 
 > Issue #N: **<title>**
 > Tasks derived from the issue:
@@ -172,7 +199,7 @@ gh issue view <number> --json title,body,labels,comments,assignees
    - **SPEC:** `feat/<slug>`
    - **ISSUE:** `feat/<issue-number>-<slugified-title>` (max 50 chars)
    - **RAW:** Ask user or derive from first task description
-4. Raise any concerns via AskUserQuestion before starting.
+4. **Phase confirmation** — raise any concerns via AskUserQuestion before starting **only if `MODE=hitl`**. In AFK mode, log concerns to the batch report and proceed; if a concern is severe enough that proceeding would corrupt state (uncommitted changes that conflict, missing dependencies, branch-protection issues), STOP regardless of mode and report — that's a hard blocker, not a phase prompt.
 
 ---
 
@@ -207,7 +234,7 @@ Return: what you implemented, what tests you wrote, test results, any concerns."
 description: "Implement task: <task title>"
 ```
 
-**If the agent has questions:** Present them to the user via AskUserQuestion. Answer, then re-dispatch.
+**If the agent has questions:** treat as a hard blocker. In `MODE=hitl`, present via AskUserQuestion, answer, then re-dispatch. In `MODE=afk`, the orchestrator does **not** have the user's input — STOP and report: *"Task `<title>` requires HITL clarification: `<questions>`. Re-run as HITL or label the issue `hitl` and re-execute."* Do not guess; do not skip; do not silently stall waiting for input that won't come.
 
 ### 3b: Dispatch compliance reviewer
 
@@ -268,7 +295,7 @@ After quality review passes, run `/code-review` to clean up the changed code —
 
 ## Step 4: Batch Checkpoint (shared)
 
-After each batch of 3 tasks, report to the user:
+After each batch of 3 tasks, report to the user. **Phase confirmation** — present the "Continue?" prompt via AskUserQuestion **only if `MODE=hitl`**; in AFK mode, log the batch report and continue automatically to the next batch:
 
 ```text
 Batch N complete: tasks X-Y done
@@ -278,7 +305,7 @@ Batch N complete: tasks X-Y done
   Tests: all passing
 
 Next batch: tasks Y+1 to Z
-Continue? (A) Yes  (B) Review changes first  (C) Stop here
+Continue? (A) Yes  (B) Review changes first  (C) Stop here     ← MODE=hitl only
 ```
 
 ---
@@ -294,7 +321,7 @@ After all tasks are done:
      ```bash
      gh issue comment <number> --body "Implementation complete on branch \`$(git branch --show-current)\`. Changes: <summary of files changed and tests written>"
      ```
-     Ask user: "Close this issue? (A) Yes (B) No, keep open until PR merges"
+     **User-owned decision** — always ask via AskUserQuestion regardless of `MODE`: "Close this issue? (A) Yes (B) No, keep open until PR merges". Closing an issue is a state change visible outside this run; AFK does not authorize it.
    - **RAW:** No external updates.
 3. Report final status:
 

--- a/.claude/skills/guardian/SKILL.md
+++ b/.claude/skills/guardian/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@03bb002
+_origin: calsuite@dfaf5b4
 name: guardian
 description: "Configure Guardian autonomous mode, switch modes, view audit log, and manage rules"
 user-invocable: true
@@ -17,13 +17,16 @@ Parse `$ARGUMENTS` to determine the subcommand:
 
 ### `mode <autonomous|supervised|lockdown>`
 
+Accepted aliases (case-insensitive): `AFK` → `autonomous`, `HITL` → `supervised`. Both `/guardian mode AFK` and `/guardian mode autonomous` resolve to the same canonical value.
+
 Switch Guardian's operating mode:
 
-1. Read the project's `.claude/config/guardian-rules.json` (or fall back to the repo's `config/guardian-rules.json`)
-2. Update the `"mode"` field to the requested value
-3. Read the `permissions` object for the new mode
-4. Update the project's `.claude/settings.json` — merge the mode's `allow` list into `permissions.allow`
-5. Report what changed
+1. **Normalize the mode argument.** Lowercase the input. If it equals `afk`, rewrite to `autonomous`. If it equals `hitl`, rewrite to `supervised`. Otherwise validate against `{autonomous, supervised, lockdown}` and abort if it doesn't match.
+2. Read the project's `.claude/config/guardian-rules.json` (or fall back to the repo's `config/guardian-rules.json`)
+3. Update the `"mode"` field to the **normalized canonical** value (never the alias — the on-disk config stores the canonical form so other tooling reads one value, not three).
+4. Read the `permissions` object for the new mode
+5. Update the project's `.claude/settings.json` — merge the mode's `allow` list into `permissions.allow`
+6. Report what changed (include the alias the user typed if it was normalized: *"Switched to `autonomous` (alias `AFK`)."*)
 
 **Modes:**
 - **autonomous** (alias: **AFK**) — Broad permissions, guardian blocks only dangerous ops. Best for unattended work — work that can run end-to-end without human input.
@@ -31,6 +34,20 @@ Switch Guardian's operating mode:
 - **lockdown** — Minimal read-only access. For auditing or untrusted environments.
 
 **AFK vs HITL is the same axis as autonomous vs supervised.** The aliases exist because `/sweep-issues` (labelling) and `/execute` (running labelled work) use AFK/HITL — those labels map directly onto these modes when an agent picks up the work.
+
+## How AFK / HITL composes across skills
+
+AFK and HITL appear in three skills at three different layers. They compose; they don't contradict.
+
+| Layer | Skill | Question it answers |
+|---|---|---|
+| **Classification** | `/sweep-issues` | "Does this piece of work need a human in the loop?" Tags issue with `afk` or `hitl` label. |
+| **Execution** | `/execute` | "Given a labelled task, how do I run it?" AFK = end-to-end without pausing; HITL = pause at decision points and ask. |
+| **Permissions** | `/guardian` | "Which tools are even allowed in the current session?" AFK mode broadens permissions; HITL mode narrows them. |
+
+A typical flow: `/sweep-issues` files an `afk`-labelled issue → `/execute issue <n>` reads the label and runs end-to-end → `/guardian mode autonomous` is the matching permission posture for that run.
+
+**Authoritative definitions live here.** `/sweep-issues` and `/execute` reference this section rather than redefining the terms — when in doubt about how AFK/HITL behaves at a layer not visible from your current skill, read this table.
 
 ### `log [N]`
 

--- a/.claude/skills/improve-prompt/references/checklist.md
+++ b/.claude/skills/improve-prompt/references/checklist.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@73a2630
+_origin: calsuite@dfaf5b4
 ---
 
 # Audit checklist — fast pass
@@ -40,7 +40,7 @@ A single-page checklist for triaging a prompt. Use when the user wants a quick p
 
 ## Reasoning
 
-- [ ] For multi-step tasks: explicit reasoning structure in the prompt (`<thinking>` / `<answer>` tags, stepwise markers)?
+- [ ] For multi-step tasks: `<thinking>` / `<answer>` structure or adaptive thinking guidance?
 - [ ] Self-check pass at the end (`Before finishing, verify…`)?
 
 ## Over-emphasis (high-yield check on older prompts)

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@03bb002
+_origin: calsuite@dfaf5b4
 name: learn
 version: 1.0.0
 description: |
@@ -32,7 +32,16 @@ Three sibling artifacts, three different purposes — pick the right one before 
 | **CONTEXT.md term** | Domain vocabulary | A new domain term was resolved or sharpened during the conversation |
 | **ADR** (`docs/adr/NNNN-*.md`) | Architectural decisions that are hard to reverse | A real trade-off was made and a future reader will wonder "why" |
 
-If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR at `docs/adr/NNNN-kebab-title.md`. ADRs commit to the repo and survive across teams in a way learnings don't. Learnings are for everything else: smaller-scale durable facts that don't merit either.
+If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. In a multi-context repo the term goes in the relevant `<context>/CONTEXT.md`, not the root.
+
+If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR. Path depends on scope:
+
+- **System-wide decision** → `docs/adr/NNNN-kebab-title.md` at the repo root.
+- **Context-specific decision** (multi-context repos only) → `<context>/docs/adr/NNNN-kebab-title.md`, alongside that context's code.
+
+Filename convention is the same in both locations: zero-padded sequential `NNNN`, verb-led kebab title. ADRs commit to the repo and survive across teams in a way learnings don't.
+
+Learnings are for everything else: smaller-scale durable facts that don't merit either.
 
 ## Storage
 

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@03bb002
+_origin: calsuite@dfaf5b4
 name: plan
 version: 1.0.0
 description: |
@@ -195,7 +195,7 @@ Conduct a deep, multi-round interview using AskUserQuestion. The goal is to surf
 
 Interview guidelines:
 - **Do NOT ask obvious questions** that the spec already answers clearly.
-- **Do ask about:** hidden complexity, conflicting requirements, unstated assumptions, failure modes, edge cases, scaling concerns, security implications, data model subtleties, UX micro-interactions, state management tradeoffs, migration paths, backwards compatibility, error handling strategy, and integration boundaries.
+- **Do ask about:** hidden complexity, conflicting requirements, unstated assumptions, failure modes, edge cases, scaling concerns, security implications, data model subtleties, UX micro-interactions, state management tradeoffs, migration paths, backwards compatibility, error handling strategy, performance budgets, accessibility considerations, and integration boundaries.
 - **Be specific.** Reference concrete parts of the spec. Instead of "how should errors work?", ask "when this background job fails after processing 3 of 10 items, what should the user see?"
 - **Go deep on answers.** Follow up on interesting responses. If the user says "we'll use a queue", ask about retry policy, idempotency, ordering guarantees, dead letter handling.
 - **Cover multiple dimensions per round.** Keep each AskUserQuestion focused on one decision, but cover multiple topics across a round to keep the interview moving.
@@ -214,6 +214,7 @@ Rewrite the spec file incorporating all decisions from the interview:
 - Integrate all interview answers as concrete decisions (not as Q&A)
 - Add new sections for topics that emerged
 - Follow the spec format: `requirements.md`, `design.md`, `tasks.md`
+- Write it as a definitive spec, not a discussion document
 - Flag any remaining open questions
 - **If `LIFECYCLE=1`** (see Lifecycle Detection above): include a state × event matrix in `design.md` under a `## State Transitions` section. Every cell must be filled — fuzzy cells get called out as open questions.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@03bb002
+_origin: calsuite@dfaf5b4
 name: review
 version: 1.1.0
 description: |
@@ -379,22 +379,30 @@ if [ ! -s "$DIFF_FILE" ]; then
   fi
 fi
 
-# Agent F — silent failure hunter
-F_COUNT=$(grep -cE 'catch|\.catch|fallback|onError|Result<' "$DIFF_FILE" || echo 0)
+# Agent F — silent failure hunter. `grep -c` always prints the count to stdout
+# (0 on no match) and exits 1 on no match. Append `|| true` (not `|| echo 0`)
+# to absorb the exit-1: `|| echo 0` would append a second "0" and produce a
+# two-line "0\n0" string that breaks `-gt` tests, while bare `grep -c` would
+# abort the script under `set -euo pipefail`. `|| true` gives the count without
+# either failure mode.
+F_COUNT=$(grep -cE 'catch|\.catch|fallback|onError|Result<' "$DIFF_FILE" || true)
 # Agent G — type design review
-G_COUNT=$(grep -cE 'interface |type |enum |class |struct ' "$DIFF_FILE" || echo 0)
+G_COUNT=$(grep -cE 'interface |type |enum |class |struct ' "$DIFF_FILE" || true)
 # Agent H — cross-module format consistency (any touched source file qualifies).
 # Diff headers have the form "+++ b/path/to/file.ext" — grep those to count touched source files.
-H_COUNT=$(grep -cE '^\+\+\+ b/.*\.(rs|ts|tsx|js|jsx|py|go|sql)$' "$DIFF_FILE" || echo 0)
-# Agent I — spec-contract deviation (branch has a matching spec)
+H_COUNT=$(grep -cE '^\+\+\+ b/.*\.(rs|ts|tsx|js|jsx|py|go|sql)$' "$DIFF_FILE" || true)
+# Agent I — spec-contract deviation (branch has a matching spec).
+# Strip standard feature-branch prefixes, then require an exact spec directory
+# match. Do NOT fall back to "first spec under .claude/specs/" — for issue-driven
+# branches (e.g. claude/<task>) the fallback grabs an unrelated spec and Agent I
+# runs against the wrong contract. Better to skip cleanly when there's no match.
 branch=$(git branch --show-current)
 slug=$(echo "$branch" | sed -E 's#^(feat|fix|chore|refactor|feature)/##')
 SPEC_DIR=""
 [ -d ".claude/specs/$slug" ] && SPEC_DIR=".claude/specs/$slug"
-[ -z "$SPEC_DIR" ] && SPEC_DIR=$(find .claude/specs -mindepth 1 -maxdepth 2 -name design.md -exec dirname {} \; 2>/dev/null | head -1)
 
 # Also gate the versioned-struct pass inside Agent B:
-VERSIONED_STRUCT=$(grep -cE '(_VERSION|version:\s*(number|u?[0-9]+))' "$DIFF_FILE" || echo 0)
+VERSIONED_STRUCT=$(grep -cE '(_VERSION|version:\s*(number|u?[0-9]+))' "$DIFF_FILE" || true)
 ```
 
 If the respective count is 0 (or `$SPEC_DIR` empty for Agent I), skip that agent.

--- a/.claude/skills/review/checklist.md
+++ b/.claude/skills/review/checklist.md
@@ -34,6 +34,16 @@ Be terse. For each issue: one line describing the problem, one line with the fix
 
 ## Review Categories
 
+### Cross-cutting patterns
+
+Most of the citation-rich Pass 1 and Pass 2 bullets below are instances of three abstract shapes. Carry the principle into the scan so you can flag new instances the checklist doesn't yet list.
+
+- **A — State surface sync.** Any logical state with two or more surfaces (in-memory + DB, source doc + parsed store, prop + live store, event payload + frontend listener, write path + read path) must have every transition touch all surfaces. A one-sided change ships green. Instances below: *Stale in-memory state after DB write* (Race Conditions), *Conditional Side Effects* (status set on one branch only), *Aggregation Source Consistency* (totals derived from different sources with different filtering), *Derive-during-render must also sync state* (React 19 State Patterns), and the *Serialize/deserialize symmetry* check in the versioned-struct pass.
+- **B — Defensive-default trap.** Substituting an empty / default / `Ok(None)` for an error signal turns "something went wrong" into "nothing happened" — indistinguishable to callers, and the next write destroys the evidence. Instances below: the swallowed-error, catch-all-without-context, and empty-`catch {}` bullets under *Error Handling*; *Error state vs empty state* and *Feature flags inferred from API failure* under *React Async Patterns*; and the sentinel-value bullet under *Aggregation Source Consistency*.
+- **C — Stale-reference class.** After a structural change (renamed type, new enum variant, dropped param, changed contract, deleted column), every reference to the old shape must grep to zero — including comments, specs, tests, and blame-anchored claims. Instances below: the stale-comment and "all X converted" bullets under *Dead Code & Consistency*, the error-string-as-query-filter bullet under *Magic Numbers & String Coupling*, *Sibling Helper Drift*, and *Test Mock Staleness*.
+
+Not unified here: the ordering / atomicity family (TOCTOU re-reads under *SQL & Data Safety*, atomic conditional updates under *Race Conditions & Concurrency*) is a sibling concern. Same goal as A — consistency across surfaces — but the mechanism is sequencing and rollback, not symmetric writes. Treat the concrete bullets as load-bearing rather than rolling them up.
+
 ### Pass 1 — CRITICAL
 
 #### SQL & Data Safety

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@0ce554a
+_origin: calsuite@dfaf5b4
 name: ship
 version: 1.0.0
 description: |
@@ -414,13 +414,16 @@ If `strict: true` in ship-config.json, this blocks. Otherwise surface and contin
 
 ### Gate 3 — Spec-contract deviation
 
-Detect the active spec the same way `/review` Agent I does:
+Detect the active spec the same way `/review` Agent I does — strip standard
+feature-branch prefixes, then require an exact spec directory match. Do NOT
+fall back to "first spec under `.claude/specs/`" — for issue-driven branches
+(e.g. `claude/<task>`) the fallback grabs an unrelated spec and Gate 3 runs
+against the wrong contract. Better to skip cleanly when there's no match.
 ```bash
 branch=$(git branch --show-current)
 slug=$(echo "$branch" | sed -E 's#^(feat|fix|chore|refactor|feature)/##')
 SPEC_DIR=""
 [ -d ".claude/specs/$slug" ] && SPEC_DIR=".claude/specs/$slug"
-[ -z "$SPEC_DIR" ] && SPEC_DIR=$(find .claude/specs -mindepth 1 -maxdepth 2 -name design.md -exec dirname {} \; 2>/dev/null | head -1)
 ```
 
 If `$SPEC_DIR` is non-empty:

--- a/.claude/skills/sweep-issues/SKILL.md
+++ b/.claude/skills/sweep-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@03bb002
+_origin: calsuite@dfaf5b4
 name: sweep-issues
 version: 1.0.0
 description: |
@@ -13,6 +13,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - AskUserQuestion
 ---
 
 # Sweep Issues: Auto-Create GitHub Issues from Session Work
@@ -42,6 +43,7 @@ Scan the conversation for ANY of these patterns:
 - Items completed in this session
 - Items that are trivially small (single-line fixes you could do right now)
 - Vague wishes without actionable scope
+- **Bugs in code this branch is currently touching** — these belong inline in the PR, not deferred. Step 2c detects and surfaces these explicitly.
 
 ## Process
 
@@ -52,11 +54,12 @@ Review the conversation history and identify candidate items. For each, note:
 - **Why**: context from the conversation
 - **Source**: what triggered it (review finding, user comment, edge case discovered, etc.)
 - **Category**: `enhancement` | `bug` | `tech-debt` | `infrastructure`
-- **Mode**: `AFK` | `HITL`
-  - **AFK** — clearly-specified implementation, no design decisions or external access required. An agent could pick this up and run end-to-end through `/execute` autonomously.
-  - **HITL** — needs human-in-the-loop: a design decision the user must own, manual verification, external access, or domain knowledge an agent can't get from the code. Prefer AFK whenever possible — only mark HITL when there's a real reason an agent can't finish unattended.
+- **Mode**: `AFK` | `HITL` — see `/guardian`'s "How AFK/HITL composes across skills" section for authoritative definitions and how this label cascades into `/execute` runtime behavior and `/guardian` permission modes. For classification at this layer:
+  - **AFK** — clearly-specified implementation, no design decisions or external access required.
+  - **HITL** — needs a design decision, manual verification, external access, or domain knowledge an agent can't get from the code.
+  - Prefer AFK whenever possible — only mark HITL when there's a real reason an agent can't finish unattended.
 
-### Step 2: Deduplicate Against Existing Issues and Prior Rejections
+### Step 2: Filter — dedup, prior rejections, and PR-introduced bugs
 
 For each candidate:
 
@@ -74,6 +77,41 @@ If a prior rejection covers the same idea, **skip the candidate silently** and n
 
 If a prior rejection is *related but not the same scope*, surface it to the user: *"This is similar to a previous rejection (`.out-of-scope/<slug>.md`) but the new scope differs because X — proceed?"* The user decides whether the new scope warrants a new issue or whether to update the rejection record.
 
+**2c. Flag PR-introduced bugs.** A bug in code this branch is already changing belongs inline in the PR, not in a deferred issue. Skip this check on `main` or when no diff exists — otherwise it produces noise.
+
+```bash
+# Skip the check entirely if not on a feature branch with real divergence
+branch=$(git branch --show-current 2>/dev/null)
+if [ -n "$branch" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ]; then
+  changed_files=$(git diff origin/main --name-only 2>/dev/null)
+fi
+```
+
+If `$changed_files` is non-empty, for every candidate categorized as `bug`:
+
+1. Match the candidate against the diff. A candidate is **PR-touched** if any of:
+   - Its description references a file path in `$changed_files` (literal or basename match)
+   - Its description references a symbol (function, type, constant) that appears in `git diff origin/main` as an added or modified line
+2. If PR-touched, use AskUserQuestion individually:
+   ```text
+   This bug looks like it lives in code this PR is changing:
+     <one-line bug description>
+     Matched: <file path or symbol>
+
+   PR-introduced bugs should be fixed in this PR, not deferred.
+
+   A) Fix inline — skip this candidate. You'll fix it before the PR is published
+      (or as a follow-up commit if the PR is already up).
+   B) Defer to issue — confirmed pre-existing, not introduced by this branch.
+   C) Dismiss — not a real bug.
+   ```
+3. Apply the answer:
+   - **A:** drop from the create-list. Add to the final report as `Skipped (fix inline): <description>`. After Step 5, surface a clear callout reminding the user to fix before publishing.
+   - **B:** keep the candidate. Add a `**Pre-existing:** confirmed not introduced by branch <name>` line to the issue body so the next reader knows the triage already happened.
+   - **C:** drop silently.
+
+This guard runs on every `/sweep-issues` invocation, including the safety-net call at the end of `/ship`. It's the last line of defense against PR-introduced bugs slipping into deferred issues.
+
 ### Step 3: Present Candidates
 
 Show the user a numbered list:
@@ -89,10 +127,13 @@ If `--dry-run`, stop here.
 
 ### Step 4: Create Issues
 
-For each item, create a GitHub issue:
+For each item, create a GitHub issue with **both labels** — one category label (from the mapping below) and one mode label (`afk` or `hitl`):
 
 ```bash
-gh issue create --title "<title>" --label "<label>" --body "$(cat <<'EOF'
+gh issue create --title "<title>" \
+  --label "<category-label>" \
+  --label "<mode-label>" \
+  --body "$(cat <<'EOF'
 ## Summary
 {1-2 sentence description}
 
@@ -107,6 +148,8 @@ gh issue create --title "<title>" --label "<label>" --body "$(cat <<'EOF'
 EOF
 )"
 ```
+
+`<category-label>` is one of `enhancement` / `bug` / `tech-debt` / `infrastructure`. `<mode-label>` is one of `afk` / `hitl`. Both labels are required — never omit the mode label.
 
 **Label mapping:**
 - `enhancement` → `enhancement`
@@ -149,7 +192,7 @@ Format:
 ---
 slug: <kebab-slug>
 rejected: YYYY-MM-DD
-related-issues: [#NN, #MM]   # optional — issues that triggered the rejection
+related-issues: ["#NN", "#MM"]   # optional — quote each ID; bare # starts a YAML comment
 ---
 
 # <Short title>

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,419 @@
+---
+_origin: calsuite@dfaf5b4
+name: verify
+version: 1.0.0
+description: |
+  verify this works, prove it works, drive it, end-to-end check, before PR,
+  run it and check, does the change actually work, exercise the change,
+  pre-PR verification, smoke the feature.
+  The pre-PR verification loop: detect what changed (frontend / backend / full-stack),
+  run the app, drive the changed code path, capture proof (screenshots, log lines,
+  DB rows, HTTP responses), fix-and-retry up to 3× without checking in. Adapts to
+  whatever stack the downstream repo uses. Always run before opening a PR — the
+  unit tests passing is necessary, not sufficient.
+argument-hint: [skip]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Agent
+  - Skill
+  - AskUserQuestion
+---
+
+# Verify: Pre-PR end-to-end verification loop
+
+## What this skill is for
+
+Unit tests prove the function returns the right value for an input. Verify proves the **change actually works in the running app** — the button does the thing, the API writes the row, the log line gets emitted, the screen renders. Green CI is one signal; clicking the thing and watching it work is the other.
+
+The flow:
+
+```
+write code → run the app → drive the changed path → did it work?
+                              ↓ no                      ↓ yes
+                           read logs                capture evidence
+                              ↓                          ↓
+                            fix code                  finish
+                              ↓
+                          hot reload  ─────► drive again
+```
+
+**The loop runs without you in it.** Don't pause to ask the user mid-loop. If you get stuck, surface everything you tried in one message — not five.
+
+## Arguments
+
+| Arg | Required | Meaning |
+|---|---|---|
+| `skip` | optional | Bypass the verification loop entirely — prints the skip line and stops. Use when the change has no observable runtime behavior. Equivalent to the auto-skip in "When to skip" below, but forced regardless of the diff. |
+
+No argument runs the full loop (detect scope → run → drive → prove → tear down).
+
+## When to skip
+
+If `git diff origin/main --name-only` shows **only** `*.md`, `LICENSE`, `.github/`, or `*.json` config without any behavior implication, print one line and stop:
+
+```
+Verify skipped: docs/config-only change, no runtime behavior to exercise.
+```
+
+Same for the user explicitly saying "skip verify" in the arguments. Don't spin up servers for changes that can't be observed.
+
+---
+
+## Step 1: Detect the scope of the change
+
+Read the diff once and classify every changed file into a bucket. The buckets drive which sub-loops actually run:
+
+```bash
+git fetch origin main >/dev/null 2>&1 || true
+git diff origin/main --name-only > /tmp/verify-changed.txt
+```
+
+Bucket each file using path heuristics — adjust for the repo's actual layout (read `CLAUDE.md` and the directory tree first if anything is ambiguous):
+
+| Bucket | Typical paths |
+|---|---|
+| **frontend** | `app/`, `src/components/`, `src/pages/`, `src/app/`, `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`, `*.css`, `client/`, `web/`, `frontend/` |
+| **backend** | `api/`, `server/`, `routes/`, `handlers/`, `services/`, `models/`, `backend/`, `*.go`, `*.py` under server dirs, route definitions |
+| **schema** | `migrations/`, `schema.sql`, `prisma/schema.prisma`, `*.dbml`, model files declaring columns |
+| **infra** | `Dockerfile*`, `docker-compose*.yml`, `k8s/`, `terraform/`, `nginx.conf` |
+| **docs/config** | `*.md`, `.github/`, `*.json` config files with no behavior implication |
+
+Hold the result as `SCOPE = { frontend, backend, schema, infra, crossCutting }` where `crossCutting = frontend && backend` (the gold case — UI does a thing, backend writes a row, you prove both).
+
+State the scope back to the user in one line so they can correct it:
+
+```
+Scope: frontend + backend (cross-cutting). Will start both servers, drive via UI,
+       assert backend log line and DB row.
+```
+
+Only proceed once you're confident in the scope — if the diff is genuinely ambiguous, ask. Misdetecting "this is just a CSS change" when it actually touches state is the failure mode that makes verify useless.
+
+---
+
+## Step 2: Discover how to run the app
+
+There are three places to look, in order of authority:
+
+1. **`.claude/verify-config.json`** if it exists — the project has declared how to run itself. Use exactly what it says. See `references/config-schema.md` for the shape.
+2. **`CLAUDE.md`** — project-specific instructions almost always mention the dev command.
+3. **Auto-discovery** — `package.json` scripts (`dev`, `start`, `serve`), a `Makefile` (`make dev`, `make up`), `docker-compose.yml` (`docker compose up`), `manage.py runserver`, `cargo run`, `go run ./cmd/server`. See `references/discover-stack.md`.
+
+Pick the **one-command** path. If the project has both `npm run dev` and `docker compose up`, prefer whichever the README/CLAUDE.md treats as canonical. If neither is clear, prefer the one that doesn't need credentials — Docker compose with seeded data beats `npm run dev` that crashes on missing env vars.
+
+If you cannot find a runnable command, stop and tell the user. Verifying nothing is worse than verifying something — don't fabricate a smoke test from a guess.
+
+---
+
+## Step 3: Run it
+
+**State model — read this first.** Claude Code spawns a fresh shell for every Bash tool call. Variables you set in this step (`SERVER_PID`, `LOG`, `ts`) do NOT survive into Step 4. An `EXIT trap` registered here fires the moment THIS shell call ends — killing the server right after it becomes ready, before Step 4 runs. So the skill writes state to a singleton file (`/tmp/verify-state.env`) and every subsequent step starts by sourcing it. Teardown happens explicitly in Step 7, not via trap.
+
+### 3a. Lock check + launch
+
+```bash
+# Refuse if a previous run left state behind — explicit cleanup is safer than auto-clobber.
+if [ -f /tmp/verify-state.env ]; then
+  echo "Stale verify state at /tmp/verify-state.env — finish the previous run, or:"
+  echo "  source /tmp/verify-state.env && [ -n \"\${VERIFY_PGID:-}\" ] && kill -- -\"\$VERIFY_PGID\" 2>/dev/null; rm -f /tmp/verify-state.env"
+  exit 1
+fi
+
+VERIFY_TS=$(date +%Y-%m-%d-%H%M%S)
+VERIFY_LOG=/tmp/verify-server-${VERIFY_TS}.log
+VERIFY_DIR=.context/verify/${VERIFY_TS}
+mkdir -p "${VERIFY_DIR}/screenshots" "${VERIFY_DIR}/responses"
+
+# Scope docker compose to this run so the teardown doesn't tear down the user's other compose work.
+# Honors the project's own COMPOSE_PROJECT_NAME if set, otherwise namespaces by timestamp.
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-verify-${VERIFY_TS//[-:]/}}"
+
+# Launch in its own process group via `setsid` so the teardown can signal the whole tree.
+# `npm run dev`, `concurrently`, vite/next wrappers, Go air, etc. all spawn children — killing
+# only the parent PID leaves them orphaned holding the port.
+setsid bash -c '<dev-command> > "$1" 2>&1' _ "$VERIFY_LOG" &
+VERIFY_PID=$!
+VERIFY_PGID=$(ps -o pgid= -p "$VERIFY_PID" 2>/dev/null | tr -d ' ')
+
+# Persist state for subsequent steps. Every later step starts with: source /tmp/verify-state.env
+cat > /tmp/verify-state.env <<EOF
+VERIFY_TS=${VERIFY_TS}
+VERIFY_LOG=${VERIFY_LOG}
+VERIFY_DIR=${VERIFY_DIR}
+VERIFY_PID=${VERIFY_PID}
+VERIFY_PGID=${VERIFY_PGID}
+COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
+EOF
+echo "state: /tmp/verify-state.env (ts=${VERIFY_TS}, pid=${VERIFY_PID}, pgid=${VERIFY_PGID})"
+```
+
+### 3b. Wallclock-bounded ready poll
+
+Don't just `sleep 10`, and don't loop forever — a server stuck in init (waiting on a missing DB, prompting for input) will spin until Claude's tool timeout. Cap with a wallclock deadline:
+
+```bash
+source /tmp/verify-state.env
+TIMEOUT=${VERIFY_READY_TIMEOUT:-60}   # override via env or .claude/verify-config.json → dev.readySignal.timeoutSeconds
+START=$(date +%s)
+READY=0
+
+until curl -fsS -o /dev/null -w "%{http_code}" http://localhost:3000/ 2>/dev/null | grep -qE '^[23]'; do
+  if [ $(($(date +%s) - START)) -ge "$TIMEOUT" ]; then
+    echo "ready timeout after ${TIMEOUT}s"
+    tail -50 "$VERIFY_LOG"
+    break
+  fi
+  if ! kill -0 "$VERIFY_PID" 2>/dev/null; then
+    echo "server crashed during startup"
+    tail -50 "$VERIFY_LOG"
+    break
+  fi
+  sleep 0.5
+done
+# Set READY only if the probe actually succeeded — a process that's still alive but
+# stuck in init would otherwise false-positive past the timeout break.
+if curl -fsS -o /dev/null -w "%{http_code}" http://localhost:3000/ 2>/dev/null | grep -qE '^[23]'; then
+  READY=1
+fi
+
+if [ "$READY" != "1" ]; then
+  echo "verify aborted: server never became ready — running teardown"
+  [ -n "${VERIFY_PGID:-}" ] && kill -- -"$VERIFY_PGID" 2>/dev/null
+  rm -f /tmp/verify-state.env
+  exit 1
+fi
+```
+
+Alternative ready signals (use whichever fits the stack):
+- A log line: `until grep -q "Listening on" "$VERIFY_LOG"; do sleep 0.5; done`
+- A health endpoint: `curl -fsS http://localhost:3000/health`
+- A Docker healthcheck: `docker compose ps --format json | jq -e 'all(.Health == "healthy")'`
+
+**If startup fails repeatedly across attempts**, read the log, fix the cause (missing env var, port conflict, broken migration), retry. Cap at 3 attempts — past that, the problem is outside verify's scope.
+
+---
+
+## Step 4: Drive it
+
+This is where the loop actually proves something. The driving technique depends on the scope:
+
+### Frontend or cross-cutting → use a browser
+
+Pick the available browser tool in this order:
+1. `agent-browser` (CLI — same one `/qa` uses; install with `npm install -g agent-browser` if missing)
+2. `mcp__Claude_Preview__preview_*` (MCP — if the project is wired for it)
+3. `mcp__playwright__playwright_*` (MCP — if Playwright is installed in the project)
+
+Full driving recipes live in `references/frontend-recipes.md`. The shape is always:
+
+```
+1. Take a "before" screenshot of the page you're about to interact with
+2. Perform the user action the change enables (click the button, fill the form, navigate the route)
+3. Take an "after" screenshot
+4. Inspect the snapshot/console for errors
+```
+
+Use **dummy auth** if the app has one — most dev environments accept a header or query param. Don't sit in front of a login screen. If you don't know the bypass, check `references/frontend-recipes.md § "Unblock auth"` for the common patterns, or look in `.claude/verify-config.json`.
+
+### Backend-only → `curl` the route
+
+```bash
+curl -fsS -X POST http://localhost:3000/api/widgets \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "verify-test", "color": "red"}' \
+  | tee /tmp/verify-response.json
+```
+
+Patterns for auth headers, multipart, streaming, etc. live in `references/backend-recipes.md`.
+
+### Schema-only → run the migration and inspect
+
+Substitute the placeholders against `.claude/verify-config.json` or what `references/discover-stack.md` discovered — these are templates, not runnable commands:
+
+```bash
+<migrate-up-command>                # e.g. `npx prisma migrate dev`, `make migrate`, `python manage.py migrate`
+<db-shell> -c "\d <table>" > /tmp/verify-schema.txt   # e.g. `psql -h localhost -U dev appdev`
+# Or for Prisma: npx prisma db pull && git diff prisma/schema.prisma
+```
+
+The proof for a schema change is: migration ran without error AND the resulting schema matches the migration's intent. Don't skip the inspection — a migration that runs but doesn't actually create the column is a real failure mode.
+
+---
+
+## Step 5: Prove it
+
+Driving is not enough. You need **artefacts that a reviewer (or you, next week) can look at and believe**. The four classes:
+
+| Class | What to capture |
+|---|---|
+| **Screenshot** | Before + after of the UI change. Saved as PNG, referenced from the summary. |
+| **Log evidence** | The line(s) that prove the backend handler ran. `source /tmp/verify-state.env && grep -A2 "<expected-marker>" "$VERIFY_LOG" > "${VERIFY_DIR}/logs.txt"` |
+| **DB evidence** | The row(s) the action produced. `SELECT * FROM widgets WHERE name = 'verify-test'` saved to disk. |
+| **HTTP evidence** | The response body matches what the change promised. Diff against an expected shape. |
+
+**For cross-cutting changes, capture ALL of these.** That's what makes a cross-cutting change verified instead of "the button looks right and I hope the API call landed." The DB row is the receipt.
+
+If the backend doesn't emit a log line at the path you're verifying, **add one as part of this PR** (see `references/backend-recipes.md § "Adding log lines"` for placement and language examples). Don't treat instrumentation as out-of-scope cleanup — it's load-bearing for verifiability.
+
+Save all evidence to:
+
+```
+.context/verify/<YYYY-MM-DD-HHMMSS>/
+├── summary.md          # what was verified, scope, pass/fail, links to artefacts
+├── screenshots/
+│   ├── before-*.png
+│   └── after-*.png
+├── logs.txt            # grepped excerpts, not the full server log
+├── db.txt              # SQL queries + their results
+└── responses/          # any curl outputs worth keeping
+```
+
+The `summary.md` should be readable in 30 seconds. Until `/ship` learns to link it automatically, paste the path into the PR body yourself so a reviewer doesn't have to take your word for it.
+
+---
+
+## Step 6: The fix loop
+
+If proof fails — wrong screenshot, missing log line, HTTP 500, DB row absent — **do not restart the server and try again**. That's the user-in-the-loop antipattern.
+
+Read the actual error first:
+
+```bash
+source /tmp/verify-state.env
+tail -100 "$VERIFY_LOG"
+# Or for browser console errors:
+agent-browser --session verify snapshot | grep -i -E '(error|warning|exception)'
+```
+
+Identify the specific cause from the specific error. Apply a targeted fix to the code. Most dev servers hot-reload — you don't need to restart unless you changed config, installed a dep, or the framework requires it (Go binaries, Rust binaries). Then re-run Step 4 against the same dev server.
+
+**Cap at 3 fix attempts.** Enforce by logging every attempt — drift past 3 becomes visible in the artifact instead of buried in scrollback. Append one line per attempt to `${VERIFY_DIR}/attempts.txt` before re-running Step 4:
+
+```bash
+source /tmp/verify-state.env
+echo "$(date -u +%FT%TZ) attempt-N: <one-line: what you tried this round>" >> "${VERIFY_DIR}/attempts.txt"
+```
+
+`summary.md` (written in Step 7) embeds `attempts.txt` so reviewers can see the fix path the verify took. If three targeted fixes don't get you to green, the problem is bigger than the loop can handle. Surface:
+
+1. What you were trying to verify (the action, the expected proof)
+2. What actually happened on each attempt (the error / wrong proof)
+3. What you tried each time and why it didn't fix it
+4. Links to the saved screenshots and log excerpts
+
+Then either invoke `/debug` (it's built for exactly this systematic-investigation case) or hand back to the user with the full evidence. Don't keep looping silently — three rounds is the budget.
+
+---
+
+## Step 7: Tear down and write the summary
+
+When proof is captured, run an **explicit teardown** — no EXIT trap, because the trap from Step 3 would have fired long ago (the launching shell exited at the end of that Bash tool call).
+
+```bash
+source /tmp/verify-state.env
+
+# Kill the process group, not just the parent PID — npm/concurrently/vite/next wrappers
+# spawn children that would otherwise leak and hold the port.
+[ -n "${VERIFY_PGID:-}" ] && kill -- -"$VERIFY_PGID" 2>/dev/null
+
+# Only down compose services this run brought up (scoped via COMPOSE_PROJECT_NAME in Step 3).
+# Leaves the user's other compose services untouched.
+if [ -n "${COMPOSE_PROJECT_NAME:-}" ] && command -v docker >/dev/null 2>&1; then
+  docker compose -p "$COMPOSE_PROJECT_NAME" down --remove-orphans 2>/dev/null || true
+fi
+
+# Custom teardown from .claude/verify-config.json — only if declared.
+if [ -f .claude/verify-config.json ]; then
+  td=$(jq -r '.teardown // empty' .claude/verify-config.json 2>/dev/null)
+  [ -n "$td" ] && bash -c "$td" || true
+fi
+
+# Release the lock so the next verify can start.
+rm -f /tmp/verify-state.env
+```
+
+Write `summary.md` with: scope detected, commands run, what was proven, links to evidence files, and `attempts.txt` if the fix loop ran. Reuse `$VERIFY_TS` and `$VERIFY_DIR` from the state file so the dir name and final message stay in sync. Output the summary path so the user (and a future `/ship` integration) can find it:
+
+```
+Verify passed. Evidence: ${VERIFY_DIR}/summary.md   # e.g. .context/verify/2026-05-29-141203/summary.md
+```
+
+---
+
+## Cannot-verify cases
+
+Some changes genuinely can't be exercised from a local dev environment:
+
+- A code path only triggered by a prod webhook
+- A cron job that runs daily
+- A migration that needs production-shaped data
+- A change behind a feature flag that's off in dev
+- A third-party integration with no sandbox
+
+For these, **do not pretend to verify**. Output explicitly:
+
+```
+Cannot verify locally: <one-line reason>.
+
+To verify manually, do:
+  1. <concrete step>
+  2. <concrete step>
+
+Recommend opening the PR with this caveat in the body.
+```
+
+Honesty here protects everyone downstream. A false "verified" is worse than no verify at all because reviewers stop looking.
+
+---
+
+## Stack adaptability
+
+Calsuite ships this skill to every target in `config/targets.json`, each with a different stack. The skill stays general by:
+
+1. **Detecting** the stack rather than assuming it (Step 1, Step 2).
+2. **Reading per-project config** if the repo has `.claude/verify-config.json` — see `references/config-schema.md` for the schema. Projects can declare their dev command, ports, log paths, DB shell, auth bypass, and seed script.
+3. **Pushing stack-specific patterns into reference files** — so the main skill stays under 400 lines and the recipes can grow without bloating context:
+   - `references/discover-stack.md` — how to sniff what's running
+   - `references/frontend-recipes.md` — Playwright / agent-browser / Claude Preview patterns, auth bypass, seed scripts
+   - `references/backend-recipes.md` — curl patterns, log grep patterns, DB query patterns, common log-line conventions
+   - `references/config-schema.md` — `.claude/verify-config.json` shape and examples
+
+Read only the reference files the scope requires. Backend-only change? You don't need `frontend-recipes.md`.
+
+---
+
+## How this integrates with `/ship`
+
+`/ship` Step 3 runs the project's unit/integration test suite. That's necessary but not sufficient — green tests + an unverified UI flow is how regressions ship.
+
+Run `/verify` **before** `/ship`. The two skills compose:
+- `/verify` proves the change works against a running app and saves evidence to `.context/verify/<ts>/summary.md`.
+- `/ship` runs unit tests, simplifies, reviews, and opens the PR.
+
+Until the integration lands, paste the `summary.md` path into the PR body yourself — `/ship` does not yet pick it up automatically. If you forget to run `/verify` first, `/ship` will not error, but the PR is weaker without the evidence. Treat them as a two-step ritual.
+
+---
+
+## Important rules
+
+- **The loop runs without the user.** Don't pause for confirmation between steps. Surface only when stuck after 3 fix attempts, or when "cannot verify" applies.
+- **Always capture evidence.** Screenshots / logs / DB rows. If you didn't save it, you didn't verify it.
+- **Always tear down processes explicitly in Step 7.** A leaked dev server eats the next session's port. Don't use a `trap ... EXIT` — it fires when the launching Bash call ends, killing the server before Step 4 runs.
+- **Add log lines if the path is opaque.** Instrumenting the change is part of verifying it, not separate cleanup.
+- **Never claim verified when you didn't.** Use the "cannot verify" template instead. False confidence is the worst output.
+- **Cap fix attempts at 3.** Past that, hand off to `/debug` or the user. Looping silently is the worst form of stuck.
+- **Read the diff before deciding scope.** Misjudging frontend-only when it's actually cross-cutting is the failure mode that makes verify useless.
+
+## Gotchas
+
+- **Hot reload is your friend.** Most dev servers reload on file save — you don't need to restart for code edits. Restart only for: env var changes, deps installed, framework binaries (Go/Rust), config files the server reads at boot.
+- **Auth bypass varies.** Some apps accept `X-Dev-User: foo@bar.com`, some need a real session, some have a `/dev/login` route. Check `references/frontend-recipes.md` or ask the user once and consider adding to `.claude/verify-config.json` for next time.
+- **Run state lives at `/tmp/verify-state.env`** because Claude Code spawns a fresh shell per Bash tool call — variables and `trap`s from Step 3 don't survive into Step 4. Every step after Step 3 starts with `source /tmp/verify-state.env`. Step 7 explicitly tears down and removes the file. If a previous run crashed mid-loop, manually run the snippet printed by Step 3a's lock check.
+- **`docker compose down` between runs** if you used Docker — orphan containers hold ports.
+- **Screenshots are evidence, not decoration.** If `agent-browser screenshot` fails, retry once before giving up. The screenshot is half the proof.
+- **The DB query is the receipt for write paths.** A successful HTTP 200 doesn't prove the row landed — it proves the handler returned. Always go one level deeper for writes.

--- a/.claude/skills/verify/references/backend-recipes.md
+++ b/.claude/skills/verify/references/backend-recipes.md
@@ -1,0 +1,223 @@
+---
+_origin: calsuite@dfaf5b4
+---
+
+# Backend verification recipes
+
+Patterns for driving HTTP / RPC / queue endpoints, reading structured logs, and querying the DB to prove a backend change actually ran.
+
+## The core loop
+
+```bash
+# 1. Make the request
+curl -fsS -X POST http://localhost:8080/api/widgets \
+  -H 'Content-Type: application/json' \
+  -H 'X-Dev-User: verify@test.local' \
+  -d '{"name": "verify-test", "color": "red"}' \
+  -o /tmp/verify-response.json \
+  -w "HTTP %{http_code}\n"
+
+# 2. Assert on the response
+jq -e '.id and .name == "verify-test"' /tmp/verify-response.json
+
+# 3. Grep the log for the expected path marker
+grep -E "widget.created.*verify-test" "$VERIFY_LOG"
+
+# 4. Query the DB to confirm the row landed
+psql -h localhost -U dev appdev -c \
+  "SELECT id, name, color, created_at FROM widgets WHERE name = 'verify-test';"
+```
+
+All three layers of proof — response, log line, DB row. A 200 means the handler returned; the log means it executed the path; the row means it actually wrote.
+
+## Curl patterns
+
+### POST with JSON body
+
+```bash
+curl -fsS -X POST http://localhost:8080/api/<resource> \
+  -H 'Content-Type: application/json' \
+  -d @/tmp/verify-payload.json
+```
+
+`-fsS` is load-bearing: `-f` makes curl exit non-zero on 4xx/5xx, `-s` quiets progress, `-S` still shows errors. Without `-f`, a 500 looks like success to the shell.
+
+### File upload
+
+```bash
+curl -fsS -X POST http://localhost:8080/api/upload \
+  -F "file=@/tmp/verify-fixture.png" \
+  -F "metadata={\"alt\":\"test\"};type=application/json"
+```
+
+### Auth header
+
+```bash
+curl -fsS -H "Authorization: Bearer $(cat /tmp/verify-token)" ...
+# Or dev bypass:
+curl -fsS -H "X-Dev-User: verify@test.local" ...
+```
+
+### Streaming / SSE
+
+```bash
+# Verify the stream emits the expected event(s)
+curl -fsS -N http://localhost:8080/api/stream \
+  | head -20 \
+  | grep -F "event: widget.created"
+```
+
+`-N` disables curl buffering so events arrive promptly.
+
+### gRPC / RPC
+
+If the backend isn't HTTP:
+
+```bash
+# grpcurl
+grpcurl -plaintext -d '{"name": "verify"}' localhost:50051 widget.WidgetService/Create
+```
+
+## Log assertions
+
+The verification matrix's most powerful pattern: structured logs that Claude can grep.
+
+### What to grep for
+
+Pick a marker the change emits at the path you're verifying. Markers should be:
+- Stable across requests (not timestamps or IDs)
+- Specific to the path (not generic like `request.received`)
+- Easy to grep (no special regex chars)
+
+Good: `widget.created`, `signup.completed`, `migration.applied.0042_users`
+Bad: `received POST /api/widgets` (matches every request), `created` (matches everything)
+
+### Structured logs
+
+If logs are JSON:
+
+```bash
+jq -c 'select(.event == "widget.created" and .name == "verify-test")' "$VERIFY_LOG"
+```
+
+If they're plain text with a known format:
+
+```bash
+grep -E '"event":"widget.created".*"name":"verify-test"' "$VERIFY_LOG"
+```
+
+### Adding log lines
+
+If the path you're verifying is silent — no log line emits when the handler runs — **add one as part of this PR**. The line costs ~1ms, makes the path observable forever, and lets verify prove itself on every future change.
+
+```python
+# Python
+logger.info("widget.created", extra={"id": widget.id, "name": widget.name})
+```
+```typescript
+// TypeScript
+logger.info({ event: "widget.created", id: widget.id, name: widget.name });
+```
+```go
+// Go
+logger.Info("widget.created", "id", widget.ID, "name", widget.Name)
+```
+
+Pick the right spot — after the write commits, before returning the response. A log line that fires before the write is a lie.
+
+## DB query patterns
+
+The receipt for any write path. Don't trust HTTP 200 alone for writes.
+
+### Postgres
+
+```bash
+psql -h localhost -U dev appdev -c \
+  "SELECT * FROM widgets WHERE name = 'verify-test' ORDER BY id DESC LIMIT 1;"
+```
+
+For JSON columns:
+```bash
+psql -h localhost -U dev appdev -c \
+  "SELECT id, metadata->>'color' FROM widgets WHERE metadata->>'name' = 'verify-test';"
+```
+
+### MySQL
+
+```bash
+mysql -h localhost -u dev -ppassword appdev -e \
+  "SELECT * FROM widgets WHERE name = 'verify-test' ORDER BY id DESC LIMIT 1;"
+```
+
+### SQLite
+
+```bash
+sqlite3 /path/to/db.sqlite \
+  "SELECT * FROM widgets WHERE name = 'verify-test' ORDER BY id DESC LIMIT 1;"
+```
+
+### MongoDB
+
+```bash
+mongosh appdev --quiet --eval \
+  'db.widgets.find({ name: "verify-test" }).sort({ _id: -1 }).limit(1).pretty()'
+```
+
+### ORM-specific
+
+For Prisma:
+```bash
+npx prisma studio &   # GUI; use only if scripting fails
+# Or programmatic:
+node -e "
+  const { PrismaClient } = require('@prisma/client');
+  const p = new PrismaClient();
+  p.widget.findFirst({ where: { name: 'verify-test' }}).then(console.log).then(()=>process.exit());
+"
+```
+
+## Cleaning up test data
+
+Each verify run leaves rows behind. Two strategies:
+
+1. **Unique markers per run** — name the row `verify-test-$(date +%s)` so successive runs don't collide. Don't delete; let it accumulate.
+2. **Cleanup at the end** — `DELETE FROM widgets WHERE name LIKE 'verify-test%'` in the teardown step.
+
+For dev DBs, accumulation is usually fine. For shared DBs (don't use these for verify), cleanup matters.
+
+## Sidecar services
+
+If the backend depends on Redis, Postgres, RabbitMQ, etc., they need to be running too. Use `docker compose up -d` to bring them all up at once, and check health before driving:
+
+```bash
+docker compose ps --format json | jq -e 'all(.Health == "healthy" or .State == "running")'
+```
+
+If a sidecar is missing health metadata, fall back to a connect-test:
+
+```bash
+redis-cli -h localhost ping  # expect PONG
+pg_isready -h localhost -U dev
+```
+
+## Replaying production traffic
+
+For changes affecting handlers that take complex inputs (webhooks, GraphQL queries, gRPC), the strongest verification is replaying a real captured request:
+
+```bash
+# Save a real request from prod logs (or a fixture)
+cat /tmp/verify-captured.json | curl -fsS -X POST http://localhost:8080/webhook \
+  -H 'Content-Type: application/json' \
+  -d @-
+```
+
+This catches edge cases hand-crafted fixtures miss. If the repo has a `fixtures/` or `testdata/` directory of captured payloads, prefer those over invented ones.
+
+## Common pitfalls
+
+- **`curl` without `-f`** — 5xx looks like success. Always `-fsS`.
+- **No `-w "%{http_code}"`** — you don't see the status code unless it errored. Add it for the log.
+- **Forgetting Content-Type** — many APIs return 415 silently. Always set it for JSON/multipart.
+- **Log line timing** — if you log before the DB commit, the line proves nothing. Log after the write returns.
+- **DB caching** — some ORMs cache reads. If your query returns stale data, force a fresh connection.
+- **Async writes** — if the handler queues a job, the DB row appears later. Either poll for the row (with a timeout) or verify the queue entry instead.

--- a/.claude/skills/verify/references/config-schema.md
+++ b/.claude/skills/verify/references/config-schema.md
@@ -1,0 +1,206 @@
+---
+_origin: calsuite@dfaf5b4
+---
+
+# `.claude/verify-config.json` schema
+
+Optional per-project config that tells `/verify` how to run the app, where logs go, how to bypass auth, and how to query the DB. Without this file, the skill auto-discovers from `package.json` / `Makefile` / `CLAUDE.md`. With it, the skill skips guessing and uses what the project declares.
+
+Recommended once the same project has been verified more than twice — auto-discovery is fine for one-off, but a declared config is faster and more reliable on repeat runs.
+
+## Full schema (all fields optional)
+
+```json
+{
+  "scope": {
+    "frontendPaths": ["src/components/**", "src/pages/**", "app/**"],
+    "backendPaths": ["api/**", "server/**", "src/server/**"],
+    "schemaPaths": ["migrations/**", "prisma/schema.prisma"]
+  },
+  "dev": {
+    "command": "docker compose up -d && npm run dev",
+    "readySignal": {
+      "type": "http",
+      "url": "http://localhost:3000/health",
+      "expectStatus": 200,
+      "timeoutSeconds": 60
+    },
+    "frontend": {
+      "command": "npm run dev:frontend",
+      "port": 3000,
+      "readyPath": "/"
+    },
+    "backend": {
+      "command": "npm run dev:backend",
+      "port": 8080,
+      "readyPath": "/api/health"
+    }
+  },
+  "teardown": "docker compose down",
+  "logs": {
+    "path": "/tmp/verify-server.log",
+    "format": "json"
+  },
+  "db": {
+    "shellCommand": "psql -h localhost -U dev appdev",
+    "queryFlag": "-c"
+  },
+  "auth": {
+    "type": "header",
+    "header": "X-Dev-User",
+    "value": "verify@test.local",
+    "loginUrl": "http://localhost:3000/dev/login?email=verify@test.local"
+  },
+  "seed": "npm run seed:verify",
+  "evidenceDir": ".context/verify"
+}
+```
+
+## Field reference
+
+### `scope`
+
+Override the default path-bucketing heuristics if the repo has an unusual layout. Each array is a list of globs.
+
+If omitted, the skill uses the defaults in `SKILL.md § "Step 1: Detect the scope"`.
+
+### `dev`
+
+How to start the app. Two modes:
+
+**Single-command mode** (typical):
+```json
+"dev": { "command": "npm run dev", "readySignal": { ... } }
+```
+
+**Split mode** (frontend + backend run separately, e.g. classic SPA + API):
+```json
+"dev": {
+  "frontend": { "command": "...", "port": 3000, "readyPath": "/" },
+  "backend":  { "command": "...", "port": 8080, "readyPath": "/health" }
+}
+```
+
+In split mode, the skill only starts what the scope needs — backend-only change skips the frontend server.
+
+### `dev.readySignal`
+
+Three types:
+
+```json
+{ "type": "http", "url": "http://localhost:3000/health", "expectStatus": 200, "timeoutSeconds": 60 }
+{ "type": "log",  "pattern": "Listening on", "timeoutSeconds": 30 }
+{ "type": "port", "port": 3000, "timeoutSeconds": 30 }
+```
+
+The skill polls until the signal arrives or the timeout hits. Without this field, it defaults to polling port + log for `(ready|listening|started)`.
+
+### `teardown`
+
+A command to run during explicit Step 7 teardown. Typical: `docker compose down`, or a custom cleanup script. The skill always kills the dev-server process group — `teardown` is for sidecars.
+
+### `logs`
+
+Where the dev server writes structured logs. The skill greps this file for proof markers.
+
+```json
+"logs": { "path": "logs/dev.log", "format": "json" }
+```
+
+`format: "json"` enables `jq`-based queries; `format: "text"` falls back to plain `grep`.
+
+If the dev server logs to stdout and you want to capture it, point `logs.path` at `/tmp/verify-server.log` and the skill will redirect stdout/stderr there when starting.
+
+### `db`
+
+How to run a query for the DB-row receipt. The skill assembles:
+
+```bash
+<shellCommand> <queryFlag> "<sql>"
+```
+
+For Postgres: `psql -h localhost -U dev appdev -c "SELECT ..."` →
+```json
+"db": { "shellCommand": "psql -h localhost -U dev appdev", "queryFlag": "-c" }
+```
+
+For SQLite: `sqlite3 /path/db.sqlite "SELECT ..."` →
+```json
+"db": { "shellCommand": "sqlite3 /path/db.sqlite", "queryFlag": "" }
+```
+
+For MongoDB:
+```json
+"db": { "shellCommand": "mongosh appdev --quiet --eval", "queryFlag": "" }
+```
+
+### `auth`
+
+How to authenticate the verify session. Four types:
+
+```json
+{ "type": "header", "header": "X-Dev-User", "value": "verify@test.local" }
+{ "type": "loginUrl", "loginUrl": "http://localhost:3000/dev/login?email=v@x.io" }
+{ "type": "form", "url": "/login", "email": "v@x.io", "password": "test1234" }
+{ "type": "none" }
+```
+
+- **header**: most dev-friendly; the skill adds the header to all curl/browser requests.
+- **loginUrl**: opens the URL once to set a session cookie before driving the real page.
+- **form**: navigates to the login page, fills, submits.
+- **none**: app has no auth in dev.
+
+### `seed`
+
+Command to seed the DB with known state before driving. Run once per verify session, after the server is up:
+
+```json
+"seed": "npm run seed:verify"
+```
+
+If the project has fixtures already loaded by `docker compose`, omit this.
+
+### `evidenceDir`
+
+Where to save screenshots, log excerpts, DB query results. Defaults to `.context/verify/` (which `/ship` knows to link from PR bodies).
+
+## Examples
+
+### Minimal — Next.js fullstack app
+
+```json
+{
+  "dev": { "command": "npm run dev" },
+  "logs": { "path": "/tmp/verify-server.log" },
+  "db":   { "shellCommand": "sqlite3 ./dev.db", "queryFlag": "" }
+}
+```
+
+### Monorepo with Docker
+
+```json
+{
+  "dev": {
+    "command": "docker compose up -d && pnpm --filter web dev",
+    "readySignal": { "type": "http", "url": "http://localhost:3000", "expectStatus": 200 }
+  },
+  "teardown": "docker compose down",
+  "logs": { "path": "/tmp/verify-server.log", "format": "json" },
+  "db":   { "shellCommand": "psql -h localhost -U postgres app", "queryFlag": "-c" },
+  "auth": { "type": "header", "header": "X-Dev-User", "value": "verify@test.local" }
+}
+```
+
+### Django backend + React frontend (split)
+
+```json
+{
+  "dev": {
+    "frontend": { "command": "cd web && npm run dev", "port": 3000, "readyPath": "/" },
+    "backend":  { "command": "python manage.py runserver 0.0.0.0:8000", "port": 8000, "readyPath": "/api/health" }
+  },
+  "logs": { "path": "/tmp/verify-django.log" },
+  "db":   { "shellCommand": "psql -h localhost -U dev djangodev", "queryFlag": "-c" },
+  "auth": { "type": "loginUrl", "loginUrl": "http://localhost:8000/dev-login/?email=v@x.io" }
+}
+```

--- a/.claude/skills/verify/references/discover-stack.md
+++ b/.claude/skills/verify/references/discover-stack.md
@@ -1,0 +1,130 @@
+---
+_origin: calsuite@dfaf5b4
+---
+
+# Discovering the stack
+
+How to figure out what the project is and how to run it, without assuming.
+
+## Order of authority
+
+1. `.claude/verify-config.json` — explicit declaration, trust it absolutely.
+2. `CLAUDE.md` — usually has a "how to run" section.
+3. The README — sometimes more accurate than CLAUDE.md.
+4. Auto-discovery from the files below.
+
+## Auto-discovery signals
+
+### `package.json`
+
+```bash
+test -f package.json && jq -r '.scripts | keys[]' package.json
+```
+
+The canonical script names, in priority order:
+- `dev` — almost always the right one
+- `start:dev`, `start-dev`
+- `serve`
+- `start` — only if no `dev`; sometimes runs prod build
+
+Detect what `dev` actually starts:
+- `next dev` → Next.js (port 3000 default)
+- `vite` → Vite SPA (port 5173 default)
+- `nuxt dev` → Nuxt (port 3000)
+- `nodemon`, `tsx watch`, `ts-node-dev` → Node server, port varies
+- `concurrently` / `npm-run-all` → multiple processes, may need to dig
+
+Detect the stack from `dependencies` / `devDependencies`:
+- `react`, `react-dom` → React
+- `vue` → Vue
+- `svelte`, `@sveltejs/kit` → Svelte/SvelteKit
+- `next` → Next.js (fullstack-capable)
+- `express`, `fastify`, `hono`, `@nestjs/core` → Node backend
+- `prisma`, `drizzle-orm`, `typeorm`, `mongoose` → DB layer
+
+### `Makefile`
+
+```bash
+test -f Makefile && grep -E '^[a-zA-Z_-]+:' Makefile | head -20
+```
+
+Common targets:
+- `make dev`, `make run`, `make serve`
+- `make up` — usually `docker compose up`
+- `make test`, `make e2e`
+- `make migrate`, `make seed`
+
+### `docker-compose.yml`
+
+```bash
+test -f docker-compose.yml && yq -r '.services | keys[]' docker-compose.yml 2>/dev/null
+# Or without yq:
+test -f docker-compose.yml && grep -E '^  [a-zA-Z_-]+:' docker-compose.yml
+```
+
+If present, `docker compose up -d` is almost always the right way to start the backend (with DB, Redis, etc.). Ports are declared in the file under `ports:`.
+
+### Python projects
+
+```bash
+test -f pyproject.toml && cat pyproject.toml | grep -E '(django|fastapi|flask|uvicorn)'
+test -f manage.py && echo "Django: python manage.py runserver"
+test -f main.py && grep -l "FastAPI\|Flask" main.py
+```
+
+Common commands:
+- Django: `python manage.py runserver` (port 8000)
+- FastAPI: `uvicorn main:app --reload` (port 8000)
+- Flask: `flask run` (port 5000)
+
+### Go projects
+
+```bash
+test -f go.mod && grep -E '^(module|go)' go.mod
+ls cmd/ 2>/dev/null  # standard layout: cmd/<service>/main.go
+```
+
+`go run ./cmd/<service>` or `air` (hot-reload tool) if installed.
+
+### Rust projects
+
+```bash
+test -f Cargo.toml && grep -A1 '\[package\]' Cargo.toml
+```
+
+`cargo run` for a single-binary project; check `[[bin]]` entries for multi-binary.
+
+### Monorepos
+
+If you see `pnpm-workspace.yaml`, `lerna.json`, `nx.json`, `turbo.json`, or `package.json` with a `workspaces` field, the dev command is usually scoped:
+
+- pnpm: `pnpm --filter <pkg> dev`
+- turbo: `turbo run dev` (runs all in parallel)
+- nx: `nx serve <app>`
+
+Check the root README — monorepos almost always document the recommended dev command.
+
+## Port discovery
+
+After starting the server, find what port it's listening on (don't assume 3000):
+
+```bash
+# From the log (source state from Step 3 for $VERIFY_LOG / $VERIFY_PID)
+source /tmp/verify-state.env
+grep -oE 'http://localhost:[0-9]+' "$VERIFY_LOG" | head -1
+
+# Or check the process
+lsof -iTCP -sTCP:LISTEN -P -n | grep "$VERIFY_PID"
+```
+
+Save the port to a shell variable; subsequent steps use it.
+
+## What to do when discovery fails
+
+If none of the above turn up a runnable command:
+
+1. Read the README and `CLAUDE.md` once more, looking for *anything* that hints at a dev command.
+2. Look for shell scripts in `scripts/`, `bin/`, `dev/` — projects sometimes hide the command there.
+3. As a last resort, ask the user: "I can't find how to start the dev server. What's the command?"
+
+Don't fabricate a guess. A wrong `npm run dev` that fails three times wastes more time than asking.

--- a/.claude/skills/verify/references/frontend-recipes.md
+++ b/.claude/skills/verify/references/frontend-recipes.md
@@ -1,0 +1,167 @@
+---
+_origin: calsuite@dfaf5b4
+---
+
+# Frontend verification recipes
+
+Patterns for driving the browser and capturing UI evidence. The goal is always the same: take a screenshot before, perform the user action the change enables, take a screenshot after, check the console.
+
+## Picking a browser tool
+
+In order of preference:
+
+1. **`agent-browser`** (CLI) — same one `/qa` uses. Install with `npm install -g agent-browser && agent-browser install`. Stable session model, good for the verify loop.
+2. **`mcp__Claude_Preview__preview_*`** — Anthropic-internal MCP, lighter-weight, good for ephemeral previews.
+3. **`mcp__playwright__playwright_*`** — if the project already has Playwright installed.
+
+Check which is available:
+
+```bash
+which agent-browser 2>/dev/null && echo "use agent-browser"
+# Otherwise check the MCP tool list in the system reminder
+```
+
+The rest of this file uses `agent-browser` syntax. Translate one-to-one for the MCP variants — the operations are the same (open, snapshot, click, fill, screenshot).
+
+## Session isolation
+
+Always pass `--session verify` so you don't collide with `/qa` or other browser users:
+
+```bash
+agent-browser --session verify open http://localhost:3000
+```
+
+## The core loop
+
+```bash
+# Source state from Step 3 — VERIFY_DIR points at .context/verify/<ts>/, screenshots/ already exists
+source /tmp/verify-state.env
+
+# 1. Open the page that contains the change
+agent-browser --session verify open http://localhost:3000/signup
+
+# 2. Before screenshot — VERIFY_DIR/screenshots/ was created in Step 3a. If you bypass Step 3
+#    (e.g. testing the recipe standalone), run `mkdir -p "${VERIFY_DIR}/screenshots"` first —
+#    agent-browser does not auto-create parents and the screenshot will fail silently.
+agent-browser --session verify screenshot "${VERIFY_DIR}/screenshots/before-signup.png"
+
+# 3. Snapshot to get @ref IDs
+agent-browser --session verify snapshot
+
+# 4. Drive the action (use the @refs from the snapshot)
+agent-browser --session verify fill @email "verify@test.local"
+agent-browser --session verify fill @password "test1234"
+agent-browser --session verify click @submit
+
+# 5. Wait for the response
+agent-browser --session verify wait 2000
+
+# 6. After screenshot
+agent-browser --session verify screenshot "${VERIFY_DIR}/screenshots/after-signup.png"
+
+# 7. Look for errors — hard errors fail the verify; warnings are surfaced but non-blocking
+#    (see "Console error handling" below for why warnings alone don't fail).
+agent-browser --session verify snapshot | grep -i -E '(error|exception|failed)'
+agent-browser --session verify snapshot | grep -i 'warning' || true
+```
+
+## Asserting success
+
+A screenshot alone is not assertion — eyeballing pixels is the user's job, not yours. After the action, check that the **observable success signal** appeared:
+
+- URL changed to the expected next page: `agent-browser --session verify url`
+- Success text visible: `agent-browser --session verify find "Welcome"`
+- A specific element exists: `agent-browser --session verify snapshot | grep -F "@dashboard-nav"`
+
+For form submissions, the success signal is typically a redirect or a success message. For data display changes, the success signal is the new content rendering.
+
+## Unblock auth
+
+The single biggest blocker for the verify loop is the login screen. The dev environment should let you in trivially.
+
+### Common bypass patterns
+
+| Pattern | How to use |
+|---|---|
+| **Magic header** | Server accepts `X-Dev-User: foo@bar.com`. Set via browser tool or curl. |
+| **Dev login route** | `/dev/login?email=foo@bar.com` returns a session cookie. Open it before the main URL. |
+| **Test fixture session** | A pre-seeded user with known credentials. Fill and submit once, the cookie persists for the session. |
+| **Env-flag skip** | `AUTH_REQUIRED=false` in dev — no auth at all. Best for verify if available. |
+
+### Adding a bypass
+
+If the app has no dev-friendly auth and you're verifying repeatedly, **add one in this PR**. A small middleware that mints a user from a request header makes every future verify trivial:
+
+```js
+// Gate on a POSITIVE opt-in env — never NODE_ENV alone. Production has been known
+// to ship with NODE_ENV unset, defaulted, or shadowed by a deploy tool, which
+// would silently disable auth. ALLOW_DEV_AUTH must be set to "1" explicitly
+// (default unset = fail closed).
+if (process.env.ALLOW_DEV_AUTH === '1' && req.headers['x-dev-user']) {
+  req.user = { id: 'verify', email: String(req.headers['x-dev-user']) };
+}
+```
+
+Treat it as enabling verification, not unrelated work. The `ALLOW_DEV_AUTH=1` env var lives only in your local `.env` / dev compose file — never in any deploy config.
+
+### Documenting the bypass
+
+Once you know the bypass, add it to `.claude/verify-config.json`:
+
+```json
+{
+  "auth": {
+    "type": "header",
+    "header": "X-Dev-User",
+    "value": "verify@test.local"
+  }
+}
+```
+
+So the next verify run picks it up automatically.
+
+## Seed scripts for known state
+
+If the change is "the dashboard shows the user's recent invoices", you need invoices in the DB. Two options:
+
+1. **Project has a seed script** — run it: `npm run seed`, `make seed`, `python manage.py loaddata fixtures.json`.
+2. **No seed script** — create the data via API or DB shell as part of the verify run:
+
+```bash
+# Via API (preferred — exercises real code paths). -fsS is load-bearing: -f makes curl exit
+# non-zero on 4xx/5xx, -s quiets progress, -S still shows errors. Without -f, a 500 looks like
+# success to the shell. Content-Type is required by most JSON APIs (otherwise 415).
+curl -fsS -X POST http://localhost:3000/api/invoices \
+  -H 'Content-Type: application/json' \
+  -H 'X-Dev-User: verify@test.local' \
+  -d '{"amount": 1000, "status": "pending"}'
+
+# Via DB shell (fallback)
+psql -h localhost -U dev appdev -c "INSERT INTO invoices ..."
+```
+
+If the project lacks a seed script entirely, propose adding one — it's the same cost-benefit as adding auth bypass.
+
+## Common dev-server quirks
+
+- **Vite over-eagerly hot-reloads** — the page may reload mid-action. Add a `wait 500` after the action to settle.
+- **Next.js first-page-render is slow** — the *first* navigation after server start can take 5-10s. Add a long wait after `open` for the first interaction.
+- **React strict mode double-renders** — log lines may appear twice in dev. Don't treat doubled logs as a bug unless they also double in prod.
+- **CORS in dev** — if your verify script hits the API directly, the dev server may block it. Either drive via the UI (no CORS), or run the API server with permissive CORS in dev.
+
+## When you need real auth
+
+Some flows can't be bypassed (OAuth callbacks, magic links, SAML). For these:
+
+1. Pre-seed a session cookie via a test fixture and the API.
+2. Or, document explicitly that this flow is in the "cannot verify locally" bucket.
+
+Don't try to drive the OAuth provider's login screen — it's brittle and not what verify is for.
+
+## Console error handling
+
+After each action, snapshot and grep for errors. Treat console output as a real signal:
+
+- **Red errors** — almost always a real bug. Fix or surface.
+- **Yellow warnings** — read them; many are noise (React dev warnings, peer dep mismatches). Don't fail the verify on warnings alone unless they relate to the change.
+- **404s on assets** — flag if they're for files the change added; ignore if they're third-party tracker fails.


### PR DESCRIPTION
## Summary
Full calsuite sync to HEAD `dfaf5b4`.

**Commit 1 — additions:** adds `/verify`, refreshes `ship`.

**Commit 2 — reconciliation:** `guardian`, `plan`, `review`, `execute`, `debug`, `sweep-issues`, `learn`, `improve-prompt/references/checklist.md` held no local edits (older calsuite generation). Force-adopted to HEAD; `_origin` stamps refreshed.

Nothing skipped remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/verify` skill for automated pre-PR end-to-end verification with configurable dev setup, proof artifacts, and bounded fix loops.
  * Enhanced `/guardian` mode with alias normalization and improved cross-skill composition guidance.

* **Documentation**
  * Refined skill workflows for clearer AFK vs. supervised mode behavior across `/execute`, `/sweep-issues`, and `/guardian`.
  * Added comprehensive verification guides covering backend recipes, frontend workflows, stack discovery, and configuration schemas.
  * Updated checklist guidance and ADR recommendation criteria across multiple skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->