### PR TITLE
chore(claude): sync calsuite skills to b196ace (v2.39)

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@dfaf5b4
+_origin: calsuite@b196ace
 name: review
 version: 1.1.0
 description: |
@@ -610,7 +610,7 @@ description: "Cross-module format consistency"
 
 **Agent I — Spec-contract deviation (signal-gated: `$SPEC_DIR` non-empty):**
 
-Only dispatch if `$SPEC_DIR` is non-empty (branch slug matches a directory under `.claude/specs/` OR a spec with both `design.md` and `tasks.md` is found). If `$SPEC_DIR` is empty, skip this agent.
+Only dispatch if `$SPEC_DIR` is non-empty — i.e. the branch name, with standard feature-branch prefixes (`feat/`, `fix/`, `chore/`, `refactor/`, `feature/`) stripped, matches a spec directory under `.claude/specs/` **exactly**. There is no fallback to "first spec under `.claude/specs/`"; for issue-driven branches (e.g. `claude/<task>`) that would grab an unrelated spec and review against the wrong contract. If there's no exact match, `$SPEC_DIR` stays empty and this agent is skipped.
 
 ```text
 prompt: "Check the diff for deviations from the spec contract.

--- a/.claude/skills/sweep-issues/SKILL.md
+++ b/.claude/skills/sweep-issues/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@dfaf5b4
+_origin: calsuite@b196ace
 name: sweep-issues
 version: 1.0.0
 description: |
@@ -83,7 +83,11 @@ If a prior rejection is *related but not the same scope*, surface it to the user
 # Skip the check entirely if not on a feature branch with real divergence
 branch=$(git branch --show-current 2>/dev/null)
 if [ -n "$branch" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ]; then
-  changed_files=$(git diff origin/main --name-only 2>/dev/null)
+  # Resolve the repo's default branch instead of assuming origin/main — repos
+  # whose default is master (or anything else) would otherwise diff against a
+  # nonexistent ref and silently no-op this guard.
+  base=$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo origin/main)
+  changed_files=$(git diff "$base" --name-only 2>/dev/null)
 fi
 ```
 
@@ -91,7 +95,7 @@ If `$changed_files` is non-empty, for every candidate categorized as `bug`:
 
 1. Match the candidate against the diff. A candidate is **PR-touched** if any of:
    - Its description references a file path in `$changed_files` (literal or basename match)
-   - Its description references a symbol (function, type, constant) that appears in `git diff origin/main` as an added or modified line
+   - Its description references a symbol (function, type, constant) that appears in `git diff "$base"` (the default-branch diff resolved above) as an added or modified line
 2. If PR-touched, use AskUserQuestion individually:
    ```text
    This bug looks like it lives in code this PR is changing:
@@ -161,13 +165,17 @@ EOF
 - `AFK` → `afk` label
 - `HITL` → `hitl` label
 
-If the labels don't already exist on the repo, create them once. **Gate the create call** — `gh label create` errors on existing labels without `--force`, and `--force` would overwrite color/description on every run. Use:
+If the labels don't already exist on the repo, create them once. This covers **both** the mode labels (`afk`/`hitl`) and the custom category labels (`tech-debt`/`infrastructure`) — `gh issue create --label tech-debt` fails outright if the label is missing, which would silently drop the issue. (`enhancement` and `bug` ship as defaults on every GitHub repo, so they don't need bootstrapping.) **Gate each create call** — `gh label create` errors on existing labels without `--force`, and `--force` would overwrite color/description on every run. Use:
 
 ```bash
 gh label list --json name -q '.[].name' | grep -qx afk \
   || gh label create afk --color 0E8A16 --description "Agent can complete unattended"
 gh label list --json name -q '.[].name' | grep -qx hitl \
   || gh label create hitl --color FBCA04 --description "Needs human in the loop"
+gh label list --json name -q '.[].name' | grep -qx tech-debt \
+  || gh label create tech-debt --color D4C5F9 --description "Technical debt"
+gh label list --json name -q '.[].name' | grep -qx infrastructure \
+  || gh label create infrastructure --color C5DEF5 --description "Infrastructure / tooling"
 ``` The labels let `/execute --multi issue:...` filter for AFK-only work safe to fan out across panes, and let `/babysit-pr` flag HITL items that need user attention.
 
 ### Step 5: Report

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@dfaf5b4
+_origin: calsuite@b196ace
 name: verify
 version: 1.0.0
 description: |
@@ -32,7 +32,7 @@ Unit tests prove the function returns the right value for an input. Verify prove
 
 The flow:
 
-```
+```text
 write code → run the app → drive the changed path → did it work?
                               ↓ no                      ↓ yes
                            read logs                capture evidence
@@ -126,7 +126,12 @@ fi
 
 VERIFY_TS=$(date +%Y-%m-%d-%H%M%S)
 VERIFY_LOG=/tmp/verify-server-${VERIFY_TS}.log
-VERIFY_DIR=.context/verify/${VERIFY_TS}
+# Honor evidenceDir from .claude/verify-config.json if declared, else default.
+EVIDENCE_BASE=.context/verify
+if [ -f .claude/verify-config.json ]; then
+  EVIDENCE_BASE=$(jq -r '.evidenceDir // ".context/verify"' .claude/verify-config.json 2>/dev/null)
+fi
+VERIFY_DIR=${EVIDENCE_BASE%/}/${VERIFY_TS}
 mkdir -p "${VERIFY_DIR}/screenshots" "${VERIFY_DIR}/responses"
 
 # Scope docker compose to this run so the teardown doesn't tear down the user's other compose work.

--- a/.claude/skills/verify/references/config-schema.md
+++ b/.claude/skills/verify/references/config-schema.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@dfaf5b4
+_origin: calsuite@b196ace
 ---
 
 # `.claude/verify-config.json` schema
@@ -162,7 +162,7 @@ If the project has fixtures already loaded by `docker compose`, omit this.
 
 ### `evidenceDir`
 
-Where to save screenshots, log excerpts, DB query results. Defaults to `.context/verify/` (which `/ship` knows to link from PR bodies).
+Where to save screenshots, log excerpts, DB query results. Defaults to `.context/verify/`. `/ship` does not yet auto-pick-up this evidence — until that integration lands you paste the `summary.md` path into the PR body yourself (see `verify/SKILL.md`).
 
 ## Examples
 

--- a/.claude/skills/verify/references/frontend-recipes.md
+++ b/.claude/skills/verify/references/frontend-recipes.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@dfaf5b4
+_origin: calsuite@b196ace
 ---
 
 # Frontend verification recipes
@@ -61,7 +61,10 @@ agent-browser --session verify screenshot "${VERIFY_DIR}/screenshots/after-signu
 
 # 7. Look for errors — hard errors fail the verify; warnings are surfaced but non-blocking
 #    (see "Console error handling" below for why warnings alone don't fail).
-agent-browser --session verify snapshot | grep -i -E '(error|exception|failed)'
+#    A grep MATCH means errors are present, so it must FAIL the run — invert with -q + exit.
+if agent-browser --session verify snapshot | grep -qi -E '(error|exception|failed)'; then
+  echo "✗ console errors detected — verify failed"; exit 1
+fi
 agent-browser --session verify snapshot | grep -i 'warning' || true
 ```
 


### PR DESCRIPTION
## Summary
Syncs the v2.39 calsuite skill-doc fixes:
- `/review` — Agent I dispatch prose matches exact-match `SPEC_DIR` code
- `/sweep-issues` — default-branch resolution (not hardcoded `origin/main`); bootstrap `tech-debt`/`infrastructure` labels
- `/verify` — honor `evidenceDir` config; invert frontend console-error grep so a match fails; `config-schema` no longer claims `/ship` auto-links evidence

See calsuite CHANGELOG `[2.39]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)