### PR TITLE
chore(claude): sync calsuite skills to 4837536 (v2.40)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@b196ace
+_origin: calsuite@4837536
 name: verify
 version: 1.0.0
 description: |
@@ -131,6 +131,10 @@ EVIDENCE_BASE=.context/verify
 if [ -f .claude/verify-config.json ]; then
   EVIDENCE_BASE=$(jq -r '.evidenceDir // ".context/verify"' .claude/verify-config.json 2>/dev/null)
 fi
+# jq's `// default` only fires for a missing key in valid JSON; if jq is absent
+# or the config is malformed the command substitution is empty, which would root
+# VERIFY_DIR at `/`. Guard the empty case explicitly.
+EVIDENCE_BASE=${EVIDENCE_BASE:-.context/verify}
 VERIFY_DIR=${EVIDENCE_BASE%/}/${VERIFY_TS}
 mkdir -p "${VERIFY_DIR}/screenshots" "${VERIFY_DIR}/responses"
 


### PR DESCRIPTION
## Summary
Syncs the calsuite **v2.40** verify guard: `evidenceDir` fallback now resists a
missing `jq` / malformed `verify-config.json` (previously could root `VERIFY_DIR`
at `/`).

See calsuite CHANGELOG `[2.40]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)